### PR TITLE
Stop passing State Updates

### DIFF
--- a/notebooks/plato_tutorial.ipynb
+++ b/notebooks/plato_tutorial.ipynb
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
@@ -95,12 +95,12 @@
    "source": [
     "## 2. Adding State\n",
     "\n",
-    "We are also able to create stateful functions.  Since theano follows a functional paradigm, state updates are represented explicitely in the return value as pairs of `(symbolic_shared_variable, symbolic_updated_variable)`.  In the below example, Plato recognises that the return value is in the format \"`output, [(shared_variable, shared_variable_update)]`\", so it creates a stateful function when it compiles."
+    "We are also able to create stateful functions.  Unlike Theano, we do not pass state-updates in the return value.  Instead, we call the function `add_update(shared_var, new_value)`.  The following example shows how to make a \"function\" with some internal state that updates on each call."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 14,
    "metadata": {
     "collapsed": false
    },
@@ -116,38 +116,24 @@
    ],
    "source": [
     "import theano\n",
-    "from plato.core import symbolic\n",
+    "from plato.core import symbolic, add_update\n",
     "\n",
     "@symbolic\n",
     "def counter():\n",
-    "    counter = theano.shared(0)  # Create a shared variable, initialized at zero, which stores the count.\n",
-    "    new_count = counter+1\n",
-    "    return new_count, [(counter, new_count)]\n",
+    "    count = theano.shared(0)  # Create a shared variable, initialized at zero, which stores the count.\n",
+    "    new_count = count+1\n",
+    "    add_update(count, new_count)\n",
+    "    return new_count\n",
     "\n",
     "f = counter.compile()\n",
     "print 'I can count to ten.  See: %s' % ([int(f()) for _ in xrange(10)])\n",
     "\n",
-    "# Note that we start from scratch when we compile the function a new time, \n",
-    "# because the shared variable is initialized within the function call\n",
     "f2 = counter.compile()\n",
-    "print 'I can too: %s' % ([int(f2()) for _ in xrange(10)])\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Plato will recognise the following return formats:\n",
-    "\n",
-    "| Format                                                                   | Name/ Description                       |\n",
-    "| ------------------------------------------------------------------------ |:----------------------------------------|\n",
-    "|`out`                                                                     | **simple**: An output tensor variable               |\n",
-    "|`(out_0, out_1, ...)`                                                     | **multi**: A tuple of output tensor variables      |\n",
-    "|`[(shared_0, new_val_0), (shared_1, new_val_1), ...]`                     | **updater**: A list of updates to shared variables   |\n",
-    "|`out, [(shared_0, new_val_0), (shared_1, new_val_1), ...]`                | **single output updater**: A single output and a list of updates   |\n",
-    "|`(out_0, out_1, ...), [(shared_0, new_val_0), (shared_1, new_val_1), ...]`| **standard**: A tuple of outputs and a list of updates|\n",
-    "\n",
-    "See *Section 7: Enforcing Interfaces*, for more on the exciting topic of data formats."
+    "print 'I can too: %s' % ([int(f2()) for _ in xrange(10)])\n",
+    "# Note that we start from scratch when we compile the function a new time, \n",
+    "# because the shared variable is initialized within the function call.  If we\n",
+    "# had declaired counter outside the function, the second count would run from \n",
+    "# 11 to 20."
    ]
   },
   {
@@ -161,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 15,
    "metadata": {
     "collapsed": false
    },
@@ -189,7 +175,7 @@
     }
    ],
    "source": [
-    "from plato.core import symbolic\n",
+    "from plato.core import symbolic, add_update\n",
     "import theano\n",
     "\n",
     "class Collatz:\n",
@@ -200,12 +186,14 @@
     "    @symbolic\n",
     "    def divide_by_2(self):\n",
     "        new_value = self.value/2\n",
-    "        return new_value, [(self.value, new_value)]\n",
+    "        add_update(self.value, new_value)\n",
+    "        return new_value\n",
     "    \n",
     "    @symbolic\n",
     "    def multiply_by_3_and_add_one(self):\n",
     "        new_value = self.value*3+1\n",
-    "        return new_value, [(self.value, new_value)]\n",
+    "        add_update(self.value, new_value)\n",
+    "        return new_value\n",
     "    \n",
     "c = Collatz(20)\n",
     "div_fcn = c.divide_by_2.compile()\n",
@@ -218,7 +206,7 @@
     "    value = div_fcn() if value % 2 == 0 else mul_fcn()\n",
     "    print value\n",
     "\n",
-    "print 'Note that since the value is attached to the class, it persists if functons are recompiled.'\n",
+    "print 'Note that since the value is attached to the object, it persists if functons are recompiled.'\n",
     "new_div_fcn = c.divide_by_2.compile()\n",
     "new_mul_fcn = c.multiply_by_3_and_add_one.compile()\n",
     "for _ in xrange(6):\n",
@@ -278,7 +266,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -320,16 +308,22 @@
     "\n",
     "A big advantage of Plato is easier debugging.  There are two ways in which Plato helps you debug.\n",
     "\n",
-    "### 6A: Test values\n",
+    "### 6A: Testing Initial Values\n",
     "\n",
     "Theano allows you to add \"test-values\" to your symbolic variables ([see tutorial](http://deeplearning.net/software/theano/tutorial/debug_faq.html)).  This helps to catch shape-errors at compile-time instead of run-time, where it is difficult to find the line of code that caused them.  However, it can be a bit of extra work for the programmer, because they have to manually attach test values to their variables.  Fortunately, since Plato compiles your functions on the first pass, it can attach test-values \"under the hood\".\n",
     "\n",
-    "For example, lets look at a matrix multiplication, where we accidently get the shapes of our matrices wrong.  Since all inputs are given test values, we can easily track down the error - the traceback will lead back to the correct line.  This would not have been possible without test values, because the error would occur in the compiled code, which is no-longer linked to the source code."
+    "For example, lets look at a matrix multiplication, where we accidently get the shapes of our matrices wrong.  Since all inputs are given test values, we can easily track down the error - the traceback will lead back to the correct line.  This would not have been possible without test values, because the error would occur in the compiled code, which is no-longer linked to the source code.\n",
+    "\n",
+    "Plato attaches the following properties to all symbolic variables:  \n",
+    "**var.ival** - The initial value of the variable (a numpy array or scalar)  \n",
+    "**var.ishape** - The initial shape of the variable  \n",
+    "**var.indim** - The initial number of dimensions of the variable  \n",
+    "**var.idtype** - The initial dtype of the variable  "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -350,8 +344,8 @@
     "\n",
     "@symbolic\n",
     "def forward_pass(x, w):\n",
-    "    print 'x-shape: %s' % (x.tag.test_value.shape, )\n",
-    "    print 'w-shape: %s' % (w.tag.test_value.shape, )\n",
+    "    print 'x-shape: %s' % (x.ishape, )\n",
+    "    print 'w-shape: %s' % (w.ishape, )\n",
     "    # Note that the above test-values only display on the first iteration.\n",
     "    return x.dot(w)\n",
     "\n",
@@ -385,8 +379,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Pre-Sigmoid Activation: [[ 4.82051976  0.89245079  0.8168448 ]]\n",
-      "Post Sigmoid Activation: [[ 0.99200189  0.70939567  0.69356617]]\n"
+      "Pre-Sigmoid Activation: [[-1.98408463 -1.76282479 -0.88996526]]\n",
+      "Post Sigmoid Activation: [[ 0.12088409  0.14643691  0.291117  ]]\n",
+      "Pre-Sigmoid Activation: [[ 1.02926441 -1.8340707  -1.52472555]]\n",
+      "Post Sigmoid Activation: [[ 0.73677326  0.13775405  0.17876671]]\n",
+      "Pre-Sigmoid Activation: [[-3.41581461 -3.99078591  1.1415132 ]]\n",
+      "Post Sigmoid Activation: [[ 0.03180486  0.01814968  0.75795736]]\n"
      ]
     }
    ],
@@ -414,8 +412,9 @@
     "    \n",
     "layer = Layer(np.random.randn(n_in, n_out))\n",
     "fwd_fcn = layer.forward_pass.compile()\n",
-    "y = fwd_fcn(np.random.randn(n_samples, n_in))\n",
-    "print 'Post Sigmoid Activation: %s' % (y)"
+    "for _ in xrange(3):\n",
+    "    y = fwd_fcn(np.random.randn(n_samples, n_in))\n",
+    "    print 'Post Sigmoid Activation: %s' % (y)"
    ]
   },
   {
@@ -433,22 +432,22 @@
     "\n",
     "In larger programs, it can be useful to enforce interfaces - that is, functions are required to obey a certain contract.  This allows function A to use function B without knowing in particular which function it is.  For instance, you may have some code that iterates through a dataset and trains a predictor, but doesn't necessarily know what kind of predictor it is - just that it has a *train* function that accepts inputs and targets, and returns updates.\n",
     "\n",
-    "For this reason, we have an extended set of decorators which enforce type-checking on inputs/outputs.  Currently all these decorators just specify outputs, but this can easily be extended to to type-checking for inputs too.\n",
+    "For this reason, we have an extended set of decorators which enforce type-checking on inputs, outputs, and updates.  \n",
     "\n",
+    "`@symbolic` - No format requirements.\n",
     "`@symbolic_simple` - Returns a single output variable.  \n",
-    "`@symbolic_updater` - Returns a list of updates.  \n",
-    "`@symbolic_standard` - Returns a tuple of outputs and a list of updates.  \n",
-    "`@symbolic_multi` - Returns multiple output variables.  \n",
-    "`@symbolic_single_output_updater` - Return a single output and list of updates.  \n",
+    "`@symbolic_multi` - Returns a tuple of output tensors.  \n",
+    "`@symbolic_stateless` - Makes no state updates.\n",
+    "`@symbolic_updater` - Returns nothing and produces at least one state update.  \n",
     "\n",
-    "Refer to the table in *Section 2: Adding State* for a more detailed description of each of these formats.\n",
+    "Functions decorated with one of the above decorators throw a `SymbolicFormatError` when the function does not obey the contract specified by its decorator.\n",
     "\n",
-    "If you decorate with these, you get a `SymbolicFormatError` when your inputs/outputs are not in the expected format.  For example:"
+    "For example:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 22,
    "metadata": {
     "collapsed": false
    },
@@ -457,24 +456,25 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Trying to run improperly formatted function...\n",
-      "  SymbolicFormatError: You did not return a 2-tuple of outputs, updates.  You returned Elemwise{mul,no_inplace}.0\n",
+      "Trying to run incorrectly-decorated function...\n",
+      "  SymbolicFormatError: Function <function running_sum at 0x10d957aa0> should have created no state updates, but it created updates: [(<TensorType(int64, scalar)>, Elemwise{add,no_inplace}.0)]\n",
       "Lets try again with the correct format....\n",
-      "  [3*2] = [array(6, dtype=int32)]\n"
+      "  cumsum([1,2,3,4]) = [1, 3, 6, 10]\n"
      ]
     }
    ],
    "source": [
-    "from plato.core import symbolic_standard, SymbolicFormatError\n",
+    "from plato.core import symbolic_stateless, symbolic, SymbolicFormatError, add_update\n",
     "\n",
-    "@symbolic_standard\n",
-    "def multiply_by_two(x):\n",
-    "    y = 2*x\n",
-    "    return y  # Bad! We decorated with \"standard\" but did not return the standard format of (outputs, updates)\n",
+    "@symbolic_stateless # Bad! We decorated with \"symbolic_stateless\" but we make a state update inside\n",
+    "def running_sum(x):\n",
+    "    shared_var = theano.shared(0)\n",
+    "    y = x + shared_var\n",
+    "    add_update(shared_var, y) \n",
+    "    return y \n",
     "\n",
-    "f = multiply_by_two.compile()\n",
-    "\n",
-    "print 'Trying to run improperly formatted function...'\n",
+    "f = running_sum.compile()\n",
+    "print 'Trying to run incorrectly-decorated function...'\n",
     "try: \n",
     "    f(3)\n",
     "except SymbolicFormatError as err:\n",
@@ -482,106 +482,30 @@
     "\n",
     "print 'Lets try again with the correct format....'\n",
     "\n",
-    "@symbolic_standard\n",
-    "def multiply_by_two_in_correct_format(x):\n",
-    "    y = 2*x\n",
-    "    return (y, ), []  # Correct \"standard\" format - a tuple of outputs and a list of updates (which is empty in this case)\n",
-    "\n",
-    "f_again = multiply_by_two_in_correct_format.compile()\n",
-    "\n",
-    "print '  [3*2] = %s' % (f_again(3), )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 8. Converting Formats\n",
-    "\n",
-    "In the previous example, we saw that the `multiply_by_two` function was much cleaner than the `multiply_by_two_in_correct_format` function.  But if were to pass this function into some generic code that wants to treat functions interchangeably, we needed to implement it in the \"standard\" format.  To overcome the impracticality of forcing users to either implement functions in a messy way, or wrap them, symbolic functions have a **to_format** method to do format-conversion.  \n",
-    "\n",
-    "As an example, lets imaging you're making a generic \"Chain\" function.  Chain's job is to compose a list of (possible stateful) functions into a chain: $f_c = f_1 \\circ f_2 \\circ ... f_n$\n",
-    "\n",
-    "In our example, we'll have two functions - Multiply by two, and a cumulative sum.\n",
-    "\n",
-    "Note a few things here:  \n",
-    "- We don't know, when creating Chain, what formats the inner funtions will have (Will they return updates?, Will they return a tuple of outputs or just a single one?)\n",
-    "- We therefore don't know what format the output of Chain should take (should it return just one output or a tuple, should it return updates, etc)\n",
-    "\n",
-    "The below example shows how we can use the **to_format** method to convert a symbolic function defined in one format to another."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "sum([0..0]*2) = [array(0)] \n",
-      "sum([0..1]*2) = [array(2)] \n",
-      "sum([0..2]*2) = [array(6)] \n",
-      "sum([0..3]*2) = [array(12)] \n",
-      "sum([0..4]*2) = [array(20)] \n",
-      "sum([0..5]*2) = [array(30)] \n",
-      "sum([0..6]*2) = [array(42)] \n",
-      "sum([0..7]*2) = [array(56)] \n",
-      "sum([0..8]*2) = [array(72)] \n",
-      "sum([0..9]*2) = [array(90)] \n"
-     ]
-    }
-   ],
-   "source": [
-    "from plato.core import symbolic, symbolic_standard, symbolic_simple\n",
-    "import theano\n",
-    "import numpy as np\n",
-    "\n",
-    "@symbolic_standard\n",
-    "class Chain:\n",
-    "    \n",
-    "    def __init__(self, *functions):\n",
-    "        self.functions = functions\n",
-    "        \n",
-    "    def __call__(self, *args):\n",
-    "        updates = []\n",
-    "        for f in self.functions:\n",
-    "            # Note how we convert to the standard format to get results in the (outputs, updates) format.\n",
-    "            args, new_updates = f.to_format(symbolic_standard)(*args)  # \"*\" is python syntax for unpacking a tuple as arguments.\n",
-    "            updates += new_updates  # Append the list of this function's state updates to the global list\n",
-    "        return args, updates\n",
-    "\n",
-    "@symbolic_simple\n",
-    "def multiply_by_two(x):\n",
-    "    return x*2\n",
-    "\n",
     "@symbolic\n",
     "def running_sum(x):\n",
-    "    z = theano.shared(0)\n",
-    "    new_z = z+x\n",
-    "    return new_z, [(z, new_z)]\n",
+    "    shared_var = theano.shared(0)\n",
+    "    y = x + shared_var\n",
+    "    add_update(shared_var, y) \n",
+    "    return y \n",
     "\n",
-    "f = Chain(multiply_by_two, running_sum).compile()\n",
+    "f = running_sum.compile()\n",
     "\n",
-    "for i in xrange(10):\n",
-    "    print 'sum([0..%s]*2) = %s ' % (i, f(i))\n"
+    "print '  cumsum([1,2,3,4]) = %s' % ([int(f(i)) for i in xrange(1, 5)], )"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 9. Fixed Arguments\n",
+    "## 8. Fixed Arguments\n",
     "\n",
     "When you use a numpy array on a theano symbolic function, it treats it as a constant.  We can use the **fixed_args** argument to **compile()** to partially-specify a function.  Theano will then compile the function with these arguments as fixed constants.  For example:\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 23,
    "metadata": {
     "collapsed": false
    },
@@ -612,10 +536,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 10. Done.\n",
+    "## 9. Done.\n",
     "\n",
     "Congratulations, you made it through the Plato tutorial."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/plato_tutorial.ipynb
+++ b/notebooks/plato_tutorial.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Plato Tutorial\n",
     "\n",
-    "Plato is a python package built on top of [Theano](http://deeplearning.net/software/theano/) with two objectives:  \n",
+    "[Plato](https://github.com/petered/plato) is a python package built on top of [Theano](http://deeplearning.net/software/theano/) with two objectives:  \n",
     "1) Simplify the use of Theano.  \n",
     "2) Build a good libary of standard Deep Learning algorithms.\n",
     "\n",
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -79,7 +79,7 @@
     "z = x+y\n",
     "\n",
     "f = theano.function(inputs = [x, y], outputs = z)\n",
-    "print '3+4=%s' % f(3, 4)\n"
+    "print '3+4=%s' % f(3, 4)"
    ]
   },
   {
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
@@ -146,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
@@ -223,7 +223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
@@ -336,6 +336,7 @@
       "Now we try again with the correct shape, and it succeeds.\n",
       "x-shape: (5, 4)\n",
       "w-shape: (4, 3)\n",
+      "Success! y-shape: (5, 3)\n",
       "Note that if we run again we print nothing because the symbolic function is just run once, on the first pass.\n"
      ]
     }
@@ -349,7 +350,9 @@
     "    print 'x-shape: %s' % (x.ishape, )\n",
     "    print 'w-shape: %s' % (w.ishape, )\n",
     "    # Note that the above test-values only display on the first iteration.\n",
-    "    return x.dot(w)\n",
+    "    y = x.dot(w)\n",
+    "    print 'Success! y-shape: %s' % (y.ishape, )\n",
+    "    return y\n",
     "\n",
     "f = forward_pass.compile()\n",
     "\n",
@@ -376,7 +379,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -385,12 +388,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Pre-Sigmoid Activation: [[ 2.18475938  3.0210526   0.51141262]]\n",
-      "Post Sigmoid Activation: [[ 0.89887255  0.95351619  0.62513757]]\n",
-      "Pre-Sigmoid Activation: [[ 1.69283342 -0.37944224 -0.41909283]]\n",
-      "Post Sigmoid Activation: [[ 0.84459645  0.40626141  0.39673385]]\n",
-      "Pre-Sigmoid Activation: [[-4.57426739  0.03966451  1.64685559]]\n",
-      "Post Sigmoid Activation: [[ 0.01020856  0.50991482  0.83846563]]\n"
+      "Pre-Sigmoid Activation: [[-0.47407049 -4.29749966 -0.30280173]]\n",
+      "Post-Sigmoid Activation: [[ 0.38365325  0.01341998  0.42487273]]\n",
+      "Pre-Sigmoid Activation: [[ 1.62998915  3.40799332 -0.39556655]]\n",
+      "Post-Sigmoid Activation: [[ 0.83616817  0.96795344  0.40237799]]\n",
+      "Pre-Sigmoid Activation: [[ 0.15886441 -0.46783638 -0.82146084]]\n",
+      "Post-Sigmoid Activation: [[ 0.5396328   0.38512847  0.30545366]]\n"
      ]
     }
    ],
@@ -409,6 +412,7 @@
     "        pre_sigmoid = x.dot(self.w)\n",
     "        tdbprint(pre_sigmoid, name = 'Pre-Sigmoid Activation')  # Here we make a trace of an internal variable\n",
     "        y = tt.nnet.sigmoid(pre_sigmoid)\n",
+    "        tdbprint(y, name = 'Post-Sigmoid Activation')  # Here we make a trace of an internal variable\n",
     "        return y\n",
     "    \n",
     "n_samples = 1\n",
@@ -418,8 +422,7 @@
     "layer = Layer(np.random.randn(n_in, n_out))\n",
     "fwd_fcn = layer.forward_pass.compile()\n",
     "for _ in xrange(3):\n",
-    "    y = fwd_fcn(np.random.randn(n_samples, n_in))\n",
-    "    print 'Post Sigmoid Activation: %s' % (y)"
+    "    y = fwd_fcn(np.random.randn(n_samples, n_in))"
    ]
   },
   {
@@ -437,7 +440,7 @@
    "source": [
     "## 7. Enforcing Interfaces\n",
     "\n",
-    "In larger programs, it can be useful to enforce interfaces - that is, functions are required to obey a certain contract.  This allows function A to use function B without knowing in particular which function it is.  For instance, you may have some code that iterates through a dataset and trains a predictor, but doesn't necessarily know what kind of predictor it is - just that it has a *train* function that accepts inputs and targets, and returns updates.\n",
+    "In larger programs, it can be useful to enforce interfaces - that is, functions are required to obey a certain contract.  This allows function A to use function B without knowing in particular which function it is.  For instance, you may have some code that iterates through a dataset and trains a predictor, but doesn't necessarily know what kind of predictor it is - just that it has a *train* function that accepts inputs and targets, updates some internal state variable.\n",
     "\n",
     "For this reason, we have an extended set of decorators which enforce type-checking on inputs, outputs, and updates.  \n",
     "\n",
@@ -514,7 +517,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 13,
    "metadata": {
     "collapsed": false
    },
@@ -545,14 +548,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 9: Looping\n",
+    "## 9. Looping with scan\n",
     "\n",
-    "For looping operations in Theano, there is the **`scan`** function.  In Plato, symbolic functions have a **`.scan`** method of their own that you can call to output the result of the given function when called in a loop with the return values piled into an array.  The arguments have all the same names and semantics as Theano's scan function, so see Theano's [scan documentation](http://deeplearning.net/software/theano/library/scan.html) for details.\n"
+    "For looping operations in Theano, there is the **`scan`** function.  In Plato, symbolic functions have a **`.scan`** method of their own that you can call to output the result of the given function when called in a loop with updates applied sequentially and the return values piled into an array.  The arguments have all the same names and semantics as Theano's scan function, so see Theano's [scan documentation](http://deeplearning.net/software/theano/library/scan.html) for details.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
@@ -592,19 +595,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 9. Done.\n",
+    "## 10. Done\n",
     "\n",
-    "Congratulations, you made it through the Plato tutorial."
+    "Congratulations.  You've made it through the Plato tutorial.  You may now want to see examples of various [Learning Algorithms in Plato](https://github.com/petered/plato/wiki/Algorithms-in-Plato)."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -612,6 +606,18 @@
    "display_name": "Python 2",
    "language": "python",
    "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/plato_tutorial.ipynb
+++ b/notebooks/plato_tutorial.ipynb
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -67,6 +67,16 @@
      "output_type": "stream",
      "text": [
       "3+4=7\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/peter/projects/argmaxlab/venv/src/theano/theano/tensor/var.py:128: UserWarning: Warning, Cannot compute test value: input 0 (<TensorType(int32, scalar)>) of Op Elemwise{add,no_inplace}(<TensorType(int32, scalar)>, <TensorType(int32, scalar)>) missing default value\n",
+      "  return theano.tensor.basic.add(self, other)\n",
+      "/Users/peter/projects/argmaxlab/venv/src/theano/theano/tensor/var.py:128: UserWarning: Warning, Cannot compute test value: input 1 (<TensorType(int32, scalar)>) of Op Elemwise{add,no_inplace}(<TensorType(int32, scalar)>, <TensorType(int32, scalar)>) missing default value\n",
+      "  return theano.tensor.basic.add(self, other)\n"
      ]
     }
    ],
@@ -100,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -147,7 +157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -164,7 +174,7 @@
       "4\n",
       "2\n",
       "1\n",
-      "Note that since the value is attached to the class, it persists if functons are recompiled.\n",
+      "Note that since the value is attached to the instance, it persists if functons are recompiled.\n",
       "4\n",
       "2\n",
       "1\n",
@@ -206,7 +216,7 @@
     "    value = div_fcn() if value % 2 == 0 else mul_fcn()\n",
     "    print value\n",
     "\n",
-    "print 'Note that since the value is attached to the object, it persists if functons are recompiled.'\n",
+    "print 'Note that since the value is attached to the instance, it persists if functons are recompiled.'\n",
     "new_div_fcn = c.divide_by_2.compile()\n",
     "new_mul_fcn = c.multiply_by_3_and_add_one.compile()\n",
     "for _ in xrange(6):\n",
@@ -225,7 +235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
@@ -266,7 +276,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 5,
    "metadata": {
     "collapsed": false
    },
@@ -323,7 +333,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
@@ -370,7 +380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
@@ -379,12 +389,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Pre-Sigmoid Activation: [[-1.98408463 -1.76282479 -0.88996526]]\n",
-      "Post Sigmoid Activation: [[ 0.12088409  0.14643691  0.291117  ]]\n",
-      "Pre-Sigmoid Activation: [[ 1.02926441 -1.8340707  -1.52472555]]\n",
-      "Post Sigmoid Activation: [[ 0.73677326  0.13775405  0.17876671]]\n",
-      "Pre-Sigmoid Activation: [[-3.41581461 -3.99078591  1.1415132 ]]\n",
-      "Post Sigmoid Activation: [[ 0.03180486  0.01814968  0.75795736]]\n"
+      "Pre-Sigmoid Activation: [[ 4.40823978 -3.22244603  2.0160825 ]]\n",
+      "Post Sigmoid Activation: [[ 0.98796989  0.03832972  0.88247532]]\n",
+      "Pre-Sigmoid Activation: [[-0.84914375  1.78727461  1.03616111]]\n",
+      "Post Sigmoid Activation: [[ 0.29961251  0.85659281  0.73810861]]\n",
+      "Pre-Sigmoid Activation: [[-0.31623953  1.34197376  1.74131986]]\n",
+      "Post Sigmoid Activation: [[ 0.42159248  0.79281434  0.85085463]]\n"
      ]
     }
    ],
@@ -402,7 +412,7 @@
     "    @symbolic\n",
     "    def forward_pass(self, x):\n",
     "        pre_sigmoid = x.dot(self.w)\n",
-    "        tdbprint(pre_sigmoid, name = 'Pre-Sigmoid Activation')\n",
+    "        tdbprint(pre_sigmoid, name = 'Pre-Sigmoid Activation')  # Here we make a trace of an internal variable\n",
     "        y = tt.nnet.sigmoid(pre_sigmoid)\n",
     "        return y\n",
     "    \n",
@@ -434,20 +444,22 @@
     "\n",
     "For this reason, we have an extended set of decorators which enforce type-checking on inputs, outputs, and updates.  \n",
     "\n",
-    "`@symbolic` - No format requirements.\n",
-    "`@symbolic_simple` - Returns a single output variable.  \n",
-    "`@symbolic_multi` - Returns a tuple of output tensors.  \n",
-    "`@symbolic_stateless` - Makes no state updates.\n",
-    "`@symbolic_updater` - Returns nothing and produces at least one state update.  \n",
+    "**`@symbolic`** - No format requirements.  \n",
+    "**`@symbolic_simple`** - Returns a single output variable.  \n",
+    "**`@symbolic_multi`** - Returns a tuple of output tensors.  \n",
+    "**`@symbolic_stateless`** - Makes no state updates.  \n",
+    "**`@symbolic_updater`** - Returns nothing and produces at least one state update.  \n",
     "\n",
-    "Functions decorated with one of the above decorators throw a `SymbolicFormatError` when the function does not obey the contract specified by its decorator.\n",
+    "To make custom function con you can decorate with **`@SymbolicFunction(input_format, output_format, update_format)`**, where each of the arguments is an `IFormat` object.  See `plato.core` for examples.\n",
+    "\n",
+    "When function fail to obey the contract specified by their decorators, a `SymbolicFormatError` is raised.\n",
     "\n",
     "For example:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
@@ -457,7 +469,7 @@
      "output_type": "stream",
      "text": [
       "Trying to run incorrectly-decorated function...\n",
-      "  SymbolicFormatError: Function <function running_sum at 0x10d957aa0> should have created no state updates, but it created updates: [(<TensorType(int64, scalar)>, Elemwise{add,no_inplace}.0)]\n",
+      "  SymbolicFormatError: Function <function running_sum at 0x107169ed8> should have created no state updates, but it created updates: [(<TensorType(int64, scalar)>, Elemwise{add,no_inplace}.0)]\n",
       "Lets try again with the correct format....\n",
       "  cumsum([1,2,3,4]) = [1, 3, 6, 10]\n"
      ]
@@ -465,8 +477,9 @@
    ],
    "source": [
     "from plato.core import symbolic_stateless, symbolic, SymbolicFormatError, add_update\n",
+    "import theano\n",
     "\n",
-    "@symbolic_stateless # Bad! We decorated with \"symbolic_stateless\" but we make a state update inside\n",
+    "@symbolic_stateless # Bad! We decorated with \"symbolic_stateless\", but we make a state update inside\n",
     "def running_sum(x):\n",
     "    shared_var = theano.shared(0)\n",
     "    y = x + shared_var\n",
@@ -505,7 +518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false
    },
@@ -556,18 +569,6 @@
    "display_name": "Python 2",
    "language": "python",
    "name": "python2"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 2
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/plato_tutorial.ipynb
+++ b/notebooks/plato_tutorial.ipynb
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false
    },
@@ -67,16 +67,6 @@
      "output_type": "stream",
      "text": [
       "3+4=7\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/peter/projects/argmaxlab/venv/src/theano/theano/tensor/var.py:128: UserWarning: Warning, Cannot compute test value: input 0 (<TensorType(int32, scalar)>) of Op Elemwise{add,no_inplace}(<TensorType(int32, scalar)>, <TensorType(int32, scalar)>) missing default value\n",
-      "  return theano.tensor.basic.add(self, other)\n",
-      "/Users/peter/projects/argmaxlab/venv/src/theano/theano/tensor/var.py:128: UserWarning: Warning, Cannot compute test value: input 1 (<TensorType(int32, scalar)>) of Op Elemwise{add,no_inplace}(<TensorType(int32, scalar)>, <TensorType(int32, scalar)>) missing default value\n",
-      "  return theano.tensor.basic.add(self, other)\n"
      ]
     }
    ],
@@ -110,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false
    },
@@ -125,12 +115,11 @@
     }
    ],
    "source": [
-    "import theano\n",
-    "from plato.core import symbolic, add_update\n",
+    "from plato.core import symbolic, add_update, create_shared_variable\n",
     "\n",
     "@symbolic\n",
     "def counter():\n",
-    "    count = theano.shared(0)  # Create a shared variable, initialized at zero, which stores the count.\n",
+    "    count = create_shared_variable(0)  # Create a shared variable, initialized at zero, which stores the count.\n",
     "    new_count = count+1\n",
     "    add_update(count, new_count)\n",
     "    return new_count\n",
@@ -157,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false
    },
@@ -185,13 +174,12 @@
     }
    ],
    "source": [
-    "from plato.core import symbolic, add_update\n",
-    "import theano\n",
+    "from plato.core import symbolic, add_update, create_shared_variable\n",
     "\n",
     "class Collatz:\n",
     "\n",
     "    def __init__(self, initial_value):\n",
-    "        self.value = theano.shared(initial_value)\n",
+    "        self.value = create_shared_variable(initial_value)\n",
     "        \n",
     "    @symbolic\n",
     "    def divide_by_2(self):\n",
@@ -325,15 +313,15 @@
     "For example, lets look at a matrix multiplication, where we accidently get the shapes of our matrices wrong.  Since all inputs are given test values, we can easily track down the error - the traceback will lead back to the correct line.  This would not have been possible without test values, because the error would occur in the compiled code, which is no-longer linked to the source code.\n",
     "\n",
     "Plato attaches the following properties to all symbolic variables:  \n",
-    "**var.ival** - The initial value of the variable (a numpy array or scalar)  \n",
-    "**var.ishape** - The initial shape of the variable  \n",
-    "**var.indim** - The initial number of dimensions of the variable  \n",
-    "**var.idtype** - The initial dtype of the variable  "
+    "**`var.ival`** - The initial value of the variable (a numpy array or scalar)  \n",
+    "**`var.ishape`** - The initial shape of the variable  \n",
+    "**`var.indim`** - The initial number of dimensions of the variable  \n",
+    "**`var.idtype`** - The initial dtype of the variable  "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -344,7 +332,11 @@
      "text": [
       "x-shape: (5, 4)\n",
       "w-shape: (3, 4)\n",
-      "ValueError: shapes (5,4) and (3,4) not aligned: 4 (dim 1) != 3 (dim 0)\n"
+      "ValueError: shapes (5,4) and (3,4) not aligned: 4 (dim 1) != 3 (dim 0)\n",
+      "Now we try again with the correct shape, and it succeeds.\n",
+      "x-shape: (5, 4)\n",
+      "w-shape: (4, 3)\n",
+      "Note that if we run again we print nothing because the symbolic function is just run once, on the first pass.\n"
      ]
     }
    ],
@@ -366,7 +358,11 @@
     "    h = f(np.random.randn(5, 4), np.random.rand(3, 4))  \n",
     "except ValueError as err:\n",
     "    # If you do not catch the error, you get a stacktrace which points to the line at fault.\n",
-    "    print '%s: %s' % (err.__class__.__name__, err.message)\n"
+    "    print '%s: %s' % (err.__class__.__name__, err.message)\n",
+    "print \"Now we try again with the correct shape, and it succeeds.\"\n",
+    "h = f(np.random.randn(5, 4), np.random.rand(4, 3))  \n",
+    "print \"Note that if we run again we print nothing because the symbolic function is just run once, on the first pass.\"\n",
+    "h = f(np.random.randn(5, 4), np.random.rand(4, 3))  "
    ]
   },
   {
@@ -375,12 +371,12 @@
    "source": [
     "### 6B: Variable Traces\n",
     "\n",
-    "It can also be useful to print/plot traces of intermediate values.  Ordinarily in theano, this would require setting those variables as outputs, and restructuring code to peek at what would normally be an internal variables.  Plato does a bit of magic which allows you to print/plot/do anything with internal variables.  The following example illustrates this: "
+    "We can use **`var.ival`** and its brothers to access variable values on the first pass, but what if we want to view variable values every time the function is called?  Ordinarily in Theano, this would require setting those variables as outputs, and restructuring code to peek at what would normally be an internal variables.  Plato does a bit of magic which allows you to print/plot/do anything with internal variables.  The following example illustrates this: "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false
    },
@@ -389,25 +385,24 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Pre-Sigmoid Activation: [[ 4.40823978 -3.22244603  2.0160825 ]]\n",
-      "Post Sigmoid Activation: [[ 0.98796989  0.03832972  0.88247532]]\n",
-      "Pre-Sigmoid Activation: [[-0.84914375  1.78727461  1.03616111]]\n",
-      "Post Sigmoid Activation: [[ 0.29961251  0.85659281  0.73810861]]\n",
-      "Pre-Sigmoid Activation: [[-0.31623953  1.34197376  1.74131986]]\n",
-      "Post Sigmoid Activation: [[ 0.42159248  0.79281434  0.85085463]]\n"
+      "Pre-Sigmoid Activation: [[ 2.18475938  3.0210526   0.51141262]]\n",
+      "Post Sigmoid Activation: [[ 0.89887255  0.95351619  0.62513757]]\n",
+      "Pre-Sigmoid Activation: [[ 1.69283342 -0.37944224 -0.41909283]]\n",
+      "Post Sigmoid Activation: [[ 0.84459645  0.40626141  0.39673385]]\n",
+      "Pre-Sigmoid Activation: [[-4.57426739  0.03966451  1.64685559]]\n",
+      "Post Sigmoid Activation: [[ 0.01020856  0.50991482  0.83846563]]\n"
      ]
     }
    ],
    "source": [
     "import numpy as np\n",
-    "from plato.core import symbolic, tdbprint\n",
+    "from plato.core import symbolic, tdbprint, create_shared_variable\n",
     "import theano.tensor as tt\n",
-    "import theano\n",
     "\n",
     "class Layer:\n",
     "    \n",
     "    def __init__(self, w):\n",
-    "        self.w = theano.shared(w)\n",
+    "        self.w = create_shared_variable(w)\n",
     "        \n",
     "    @symbolic\n",
     "    def forward_pass(self, x):\n",
@@ -431,7 +426,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can also plot internal variables using the function `tdbplot` in `plato.tools.tdb_plotting`, but this tutorial does not cover it."
+    "If you want to store and retrieve internal variable values, you can use **`tdb_trace`**, and **`get_tdb_traces`** in `plato.core`.\n",
+    "\n",
+    "You can also create live plots of internal variables using the function **`tdbplot`** in `plato.tools.tdb_plotting`, but this tutorial does not cover it."
    ]
   },
   {
@@ -459,7 +456,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false
    },
@@ -469,19 +466,18 @@
      "output_type": "stream",
      "text": [
       "Trying to run incorrectly-decorated function...\n",
-      "  SymbolicFormatError: Function <function running_sum at 0x107169ed8> should have created no state updates, but it created updates: [(<TensorType(int64, scalar)>, Elemwise{add,no_inplace}.0)]\n",
+      "  SymbolicFormatError: Function <function running_sum at 0x104da58c0> should have created no state updates, but it created updates: [(<TensorType(int64, scalar)>, Elemwise{add,no_inplace}.0)]\n",
       "Lets try again with the correct format....\n",
       "  cumsum([1,2,3,4]) = [1, 3, 6, 10]\n"
      ]
     }
    ],
    "source": [
-    "from plato.core import symbolic_stateless, symbolic, SymbolicFormatError, add_update\n",
-    "import theano\n",
+    "from plato.core import symbolic_stateless, symbolic, SymbolicFormatError, add_update, create_shared_variable\n",
     "\n",
     "@symbolic_stateless # Bad! We decorated with \"symbolic_stateless\", but we make a state update inside\n",
     "def running_sum(x):\n",
-    "    shared_var = theano.shared(0)\n",
+    "    shared_var = create_shared_variable(0)\n",
     "    y = x + shared_var\n",
     "    add_update(shared_var, y) \n",
     "    return y \n",
@@ -497,7 +493,7 @@
     "\n",
     "@symbolic\n",
     "def running_sum(x):\n",
-    "    shared_var = theano.shared(0)\n",
+    "    shared_var = create_shared_variable(0)\n",
     "    y = x + shared_var\n",
     "    add_update(shared_var, y) \n",
     "    return y \n",
@@ -543,6 +539,53 @@
     "\n",
     "print '3*2 = %s' % f_mult_by_3(y=2)\n",
     "print '3*5 = %s' % f_mult_by_3(y=5)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 9: Looping\n",
+    "\n",
+    "For looping operations in Theano, there is the **`scan`** function.  In Plato, symbolic functions have a **`.scan`** method of their own that you can call to output the result of the given function when called in a loop with the return values piled into an array.  The arguments have all the same names and semantics as Theano's scan function, so see Theano's [scan documentation](http://deeplearning.net/software/theano/library/scan.html) for details.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running Cumsum of [1,2,3,4]: [ 1  3  6 10]\n",
+      "Continuing Running Cumsum of [1,2,3,4]: [11 13 16 20]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from plato.core import symbolic, create_shared_variable, add_update\n",
+    "import numpy as np\n",
+    "\n",
+    "@symbolic\n",
+    "def running_sum(x):\n",
+    "    shared_var = create_shared_variable(0)\n",
+    "    y = x + shared_var\n",
+    "    add_update(shared_var, y) \n",
+    "    return y \n",
+    "\n",
+    "@symbolic\n",
+    "def running_cumsum(arr):\n",
+    "    cumsum = running_sum.scan(sequences = [arr])\n",
+    "    return cumsum\n",
+    "\n",
+    "f = running_cumsum.compile()\n",
+    "\n",
+    "print 'Running Cumsum of [1,2,3,4]: %s' % (f(np.arange(1, 5)), )\n",
+    "print 'Continuing Running Cumsum of [1,2,3,4]: %s' % (f(np.arange(1, 5)), )\n"
    ]
   },
   {

--- a/plato/core.py
+++ b/plato/core.py
@@ -440,8 +440,6 @@ class AutoCompilingFunction(object):
             with StateCatcher(swallow_updates=True) as sc:
                 outputs = self._fcn(*tensor_args, **tensor_kwargs)
             updates = sc.get_updates()
-            # outputs, updates = detect_return_value(return_value)
-            # updates+=internal_updates  # For now we do this.  In the future, we will only allow internal updates.
             all_outputs_and_updates = convert_formats(outputs, AnyReturnFormat, MultiOutputFormat) + tuple(new for old, new in updates)
             trace_variables, trace_callbacks = _get_relevant_trace_variables_and_callbacks(all_outputs_and_updates)
             self._there_are_debug_variables = (len(trace_variables)>0 and ENABLE_TRACES) or (ENABLE_OMNISCENCE and (self._original_fcn.locals() is not None))

--- a/plato/interfaces/helpers.py
+++ b/plato/interfaces/helpers.py
@@ -1,5 +1,5 @@
 import numpy as np
-from plato.core import symbolic_simple, symbolic_standard, symbolic_single_output_updater
+from plato.core import symbolic_simple, add_update
 from plato.interfaces.decorators import find_shared_ancestors
 from plato.interfaces.interfaces import IParameterized
 from plato.tools.common.basic import softmax
@@ -207,7 +207,7 @@ def batch_normalize(x):
     return (x - x.mean(axis = 0, keepdims = True)) / (x.std(axis = 0, keepdims = True) + 1e-9)
 
 
-@symbolic_single_output_updater
+@symbolic_simple
 class SlowBatchNormalize(object):
     """
     Keeps a running mean and standard deviation, and normalizes the incoming data according to these.
@@ -225,5 +225,7 @@ class SlowBatchNormalize(object):
         running_mean_sq = theano.shared(np.zeros(x.tag.test_value.shape[1:]))
         new_running_mean = running_mean * self.decay_constant + x[0] * (1-self.decay_constant)
         new_running_mean_sq = running_mean_sq * self.decay_constant + (x[0]**2) * (1-self.decay_constant)
+        add_update(running_mean, new_running_mean)
+        add_update(running_mean_sq, new_running_mean_sq)
         running_std = tt.sqrt((new_running_mean_sq - new_running_mean**2))
-        return (x - running_mean)/(running_std+1e-7), [(running_mean, new_running_mean), (running_mean_sq, new_running_mean_sq)]
+        return (x - running_mean)/(running_std+1e-7)

--- a/plato/interfaces/helpers.py
+++ b/plato/interfaces/helpers.py
@@ -1,11 +1,8 @@
 import numpy as np
-from plato.core import symbolic_simple, add_update
-from plato.interfaces.decorators import find_shared_ancestors
+from plato.core import symbolic_simple, add_update, create_shared_variable
 from plato.interfaces.interfaces import IParameterized
 from plato.tools.common.basic import softmax
-from plato.tools.misc.tdb_plotting import tdbplot
 import theano
-from theano import Variable
 from theano.sandbox.cuda.rng_curand import CURAND_RandomStreams
 from theano.sandbox.rng_mrg import MRG_RandomStreams
 from theano.tensor.shared_randomstreams import RandomStreams
@@ -75,98 +72,6 @@ def get_theano_rng(seed, rngtype = 'mrg'):
         return seed
     else:
         raise Exception("Can't initialize a random number generator with %s" % (seed, ))
-
-
-def initialize_param(initial_value, shape = None, name = None, cast_floats_to_floatX = True):
-    """
-    Takes care of the common stuff associated with initializing a parameter.  There are a few ways you may want to
-    instantiate a parameter:
-    - With a numpy array, in which case you'll want to make sure it's the appropriate shape.
-    - With a scalar, in which case you just want a scalar shared variable.
-    - With a scalar and a shape, in which case you want an array of that shape filled with the value of the scalar.
-    - With a symbolic variable descenting from some other shared variable - this is the case when you want to tie
-      parameters together, or make the bias be the result of a previous computation, etc.
-    - With a function and shape, in which case the function should return an initial numpy array given the shape.
-    - With None, which we take to mean that this was an optional variable that should not be included, so return None
-      for variable, param, and shape.
-
-    :param initial_value: An array, scalar, or symbolic variable.:
-    :param shape: The shape that the variable should have.  None if it is already fully specified by initial_value.
-        If shape is a tuple, elements of shape s can be:
-        - integers: In which case, they mean (the dimension of in this direction shall be <s>
-        - None: In which case, the initial_value must be defined as an array, and the array may have any shape along this axis.
-    :param name: Optionally, the name for the shared variable.
-    :return: (variable, param): Variable is the shared variable, and param is the associated parameter.  If you
-        instantiated with scalar or ndarray, variable and param will be the same object.
-    """
-
-    if isinstance(shape, int):
-        shape = (shape, )
-
-    typecast = lambda x: x.astype(theano.config.floatX) if cast_floats_to_floatX and x.dtype in ('float', 'float64', 'float32') else x
-
-    if np.isscalar(initial_value):
-        if shape is None:
-            initial_value = np.array(initial_value)
-        else:
-            initial_value = np.zeros(shape)+initial_value
-        initial_value = typecast(initial_value)
-    elif hasattr(initial_value, '__call__'):
-        assert shape is not None, "If you initialize with a function, you must provide a shape."
-        initial_value = initial_value(shape)
-
-    if isinstance(initial_value, np.ndarray):
-        assert_compatible_shape(initial_value.shape, shape, name = name)
-        variable = theano.shared(typecast(initial_value), name = name, borrow = True, allow_downcast=True)
-        params = [variable]
-        variable_shape = initial_value.shape
-    elif isinstance(initial_value, Variable):
-        assert name is None or initial_value.name == name, "Can't give name '%s' to an already-existing symbolic variable" % (name, )
-        params = find_shared_ancestors(initial_value)
-        # Note to self: possibly remove this constraint for things like factored weight matrices?
-        if len(params)==1 and initial_value is params[0]:
-            variable_shape = initial_value.get_value().shape
-            assert_compatible_shape(variable_shape, shape, name = name)
-        else:
-            raise NotImplementedError("Can't yet get variable shape from base-params, though this can be done cheaply in "
-                'Theano by compiling a function wholse input is the params and whose output is the shape.')
-    elif initial_value is None:
-        variable = None
-        params = []
-        variable_shape = None
-    else:
-        raise Exception("Don't know how to instantiate variable from %s" % initial_value)
-    return variable, params, variable_shape
-
-
-def create_shared_variable(initializer_fcn, shape = None, name = None, cast_floats_to_floatX = True):
-    """
-    :param initializer_fcn: Can be:
-        - An array.  It may be cast to floatX.  It's verified with shape if shape is provided
-        - A function which takes the shape and turns it into the array.
-        - A scalar, in which case it's broadcase over shape.
-    :param shape: Either a tuple or an integer
-    :return: A shared variable, containing the numpy array returned by the initializer.
-    """
-    shared_var, _, _ = initialize_param(initializer_fcn, shape = shape, name = name, cast_floats_to_floatX=cast_floats_to_floatX)
-    return shared_var
-
-
-def assert_compatible_shape(actual_shape, desired_shape, name = None):
-    """
-    Return a boolean indicating whether the actual shape is compatible with the desired shape.  "None" serves as a wildcard.
-    :param actual_shape: A tuple<int>
-    :param desired_shape: A tuple<int> or None
-    :return: A boolean
-
-    examples (actual_desired, desired_shape : result)
-    (1, 2), None: True        # Because None matches everything
-    (1, 2), (1, None): True   # Because they have the same length, 1 matches 1 and 2 matches None
-    (1, 2), (1, 3): False     # Because 2 != 3
-    (1, 2, 1), (1, 2): False  # Because they have different lengths.
-    """
-    return desired_shape is None or len(actual_shape) == len(desired_shape) and all(ds is None or s==ds for s, ds in zip(actual_shape, desired_shape)), \
-        "Actual shape %s%s did not correspond to specified shape, %s" % (actual_shape, '' if name is None else ' of %s' %(name, ), desired_shape)
 
 
 normalize= lambda x, axis = None: x/(x.sum(axis=axis, keepdims = True) + 1e-9)

--- a/plato/interfaces/helpers.py
+++ b/plato/interfaces/helpers.py
@@ -216,15 +216,15 @@ class SlowBatchNormalize(object):
     """
 
     def __init__(self, half_life):
-        self.decay_constant = np.exp(-np.log(2)/half_life)
+        self.decay_constant = np.exp(-np.log(2)/half_life).astype(theano.config.floatX)
 
     def __call__(self, x):
         # x should have
-        assert x.tag.test_value.shape[0]==1, "This method only works for minibatches of size 1, but you used a minibatch of size: %s" % (x.tag.test_value.shape[0])
-        running_mean = theano.shared(np.zeros(x.tag.test_value.shape[1:]))
-        running_mean_sq = theano.shared(np.zeros(x.tag.test_value.shape[1:]))
-        new_running_mean = running_mean * self.decay_constant + x[0] * (1-self.decay_constant)
-        new_running_mean_sq = running_mean_sq * self.decay_constant + (x[0]**2) * (1-self.decay_constant)
+        assert x.ishape[0]==1, "This method only works for minibatches of size 1, but you used a minibatch of size: %s" % (x.tag.test_value.shape[0])
+        running_mean = create_shared_variable(np.zeros(x.tag.test_value.shape[1:]))
+        running_mean_sq = create_shared_variable(np.zeros(x.tag.test_value.shape[1:]))
+        new_running_mean = running_mean * self.decay_constant + x[0] * (1-self.decay_constant).astype(theano.config.floatX)
+        new_running_mean_sq = running_mean_sq * self.decay_constant + (x[0]**2) * (1-self.decay_constant).astype(theano.config.floatX)
         add_update(running_mean, new_running_mean)
         add_update(running_mean_sq, new_running_mean_sq)
         running_std = tt.sqrt((new_running_mean_sq - new_running_mean**2))

--- a/plato/test_core.py
+++ b/plato/test_core.py
@@ -3,7 +3,7 @@ from plato.interfaces.helpers import create_shared_variable
 from pytest import raises
 from plato.core import symbolic_simple, symbolic_updater, SymbolicFormatError, \
     tdb_trace, get_tdb_traces, symbolic, set_enable_omniscence, EnableOmbniscence, clear_tdb_traces, add_update, \
-    symbolic_multi, symbolic_stateless
+    symbolic_multi, symbolic_stateless, create_shared_variable
 import pytest
 import theano
 import numpy as np

--- a/plato/test_core.py
+++ b/plato/test_core.py
@@ -389,9 +389,9 @@ def test_scan():
 
     ar = np.random.randn(10)
     csum = f(ar)
-    assert np.allclose(csum, np.cumsum(ar))
+    assert np.allclose(csum, np.cumsum(ar), atol=1e-6)
     more_csum = f(ar)
-    assert np.allclose(more_csum, csum[-1]+np.cumsum(ar))
+    assert np.allclose(more_csum, csum[-1]+np.cumsum(ar), atol=1e-6)
 
 
 def test_catch_non_updates():
@@ -474,19 +474,19 @@ def test_ival_ishape():
 
 
 if __name__ == '__main__':
-    test_ival_ishape()
-    test_catch_sneaky_updates()
-    test_catch_non_updates()
+    # test_ival_ishape()
+    # test_catch_sneaky_updates()
+    # test_catch_non_updates()
     test_scan()
-    test_strrep()
-    test_omniscence()
-    test_named_arguments()
-    test_stateless_symbolic_function()
-    test_stateful_symbolic_function()
-    test_debug_trace()
-    test_method_caching_bug()
-    test_pure_updater()
-    test_function_format_checking()
-    test_callable_format_checking()
-    test_inhereting_from_decorated()
-    test_dual_decoration()
+    # test_strrep()
+    # test_omniscence()
+    # test_named_arguments()
+    # test_stateless_symbolic_function()
+    # test_stateful_symbolic_function()
+    # test_debug_trace()
+    # test_method_caching_bug()
+    # test_pure_updater()
+    # test_function_format_checking()
+    # test_callable_format_checking()
+    # test_inhereting_from_decorated()
+    # test_dual_decoration()

--- a/plato/test_core.py
+++ b/plato/test_core.py
@@ -441,7 +441,40 @@ def test_catch_sneaky_updates():
     assert g() == 1
 
 
+def test_ival_ishape():
+    """
+    ival, ishape, idim, idtype give the initial values, shapes, number of dimensions, and data types
+    of theano variables.  These properties are useful for input checking and debugging.
+    """
+
+    @symbolic
+    def mat_mult(a, b):
+        assert a.indim == 2 and b.indim == 2
+        assert a.idtype == theano.config.floatX and b.idtype == theano.config.floatX, 'We only take floats around these parts.'
+        assert a.ishape[1] == b.ishape[0], 'Matrices not aligned!'
+        c = a.dot(b)
+        assert c.ishape == (a.ishape[0], b.ishape[1])
+        return c
+
+    foo = np.random.randn(3, 4)
+    bar = np.random.randn(3, 3)
+    baz = np.random.randn(4, 5)
+    hap = np.random.randint(255, size = (4, 5))
+
+    f = mat_mult.compile()
+    with raises(AssertionError):
+        z = f(foo, bar)
+
+    f = mat_mult.compile()
+    with raises(AssertionError):
+        z = f(foo, hap)
+
+    z = f(foo, baz)
+    assert np.allclose(z, foo.dot(baz))
+
+
 if __name__ == '__main__':
+    test_ival_ishape()
     test_catch_sneaky_updates()
     test_catch_non_updates()
     test_scan()

--- a/plato/tools/common/basic.py
+++ b/plato/tools/common/basic.py
@@ -1,4 +1,4 @@
-from plato.interfaces.decorators import symbolic_standard
+from plato.core import add_update, symbolic_simple
 import theano
 import theano.tensor as tt
 import numpy as np
@@ -13,9 +13,11 @@ def softmax(x, axis):
     return out
 
 
-@symbolic_standard
+@symbolic_simple
 def running_average(data):
     n_points = theano.shared(np.array(1).astype(int))
     avg = theano.shared(np.zeros_like(data.tag.test_value).astype(theano.config.floatX))
     new_avg = data*(1./n_points) + avg*(n_points-1.)/n_points
-    return (new_avg, ), [(avg, new_avg), (n_points, n_points+1)]
+    add_update(avg, new_avg)
+    add_update(n_points, n_points+1)
+    return new_avg

--- a/plato/tools/dbn/dbn.py
+++ b/plato/tools/dbn/dbn.py
@@ -1,5 +1,6 @@
 from general.should_be_builtins import bad_value
-from plato.interfaces.decorators import symbolic_updater, symbolic_standard, symbolic_simple, SymbolicReturn
+from plato.core import symbolic_multi, add_update
+from plato.interfaces.decorators import symbolic_updater, symbolic_simple
 from plato.tools.optimization.optimizers import SimpleGradientDescent
 import theano
 import theano.tensor as tt
@@ -47,11 +48,11 @@ class DeepBeliefNet(object):
             self._graph.get_execution_path(InferencePath(path, default_smooth=smooth)) if path is not None else \
             self._graph.get_execution_path_from_io(input_layers, output_layers, default_smooth=smooth)
 
-        @symbolic_standard
+        @symbolic_multi
         def inference_fcn(*input_signals):
             initial_signal_dict = {lay: sig for lay, sig in zip(input_layers, input_signals)}
             computed_signal_dict = execution_path.execute(initial_signal_dict)
-            return SymbolicReturn(outputs = [computed_signal_dict[lay] for lay in output_layers], updates = [])
+            return tuple(computed_signal_dict[lay] for lay in output_layers)
 
         return inference_fcn
 
@@ -91,18 +92,15 @@ class DeepBeliefNet(object):
         @symbolic_updater
         def cd_function(*input_signals):
 
-            if input_layers is None:
-                wake_visible = input_signals
-            else:
-                wake_visible, _ = up_path(*input_signals)
-            wake_hidden, _ = propup(*wake_visible)
+            wake_visible = input_signals if input_layers is None else up_path(*input_signals)
+            wake_hidden = propup(*wake_visible)
 
             initial_hidden =[theano.shared(np.zeros(wh.tag.test_value.shape, dtype = theano.config.floatX), name = 'persistent_hidden_state') for wh in wake_hidden] \
                 if persistent else wake_hidden
 
             gibbs_path = [(hidden_layers, visible_layers)] + [(visible_layers, hidden_layers), (hidden_layers, visible_layers)] * (n_gibbs-1)
-            sleep_visible, _ = self.get_inference_function(hidden_layers, visible_layers, gibbs_path)(*initial_hidden)
-            sleep_hidden, _ = propup(*sleep_visible)
+            sleep_visible = self.get_inference_function(hidden_layers, visible_layers, gibbs_path)(*initial_hidden)
+            sleep_hidden = propup(*sleep_visible)
 
             all_params = sum([x.parameters for x in ([self._layers[i] for i in visible_layers]
                 +[self._layers[i] for i in hidden_layers]+[self._bridges[i, j] for i in visible_layers for j in hidden_layers])], [])
@@ -114,12 +112,11 @@ class DeepBeliefNet(object):
             else:
                 bad_value(method)
 
-            updates = optimizer(cost = cost, parameters = all_params, constants = wake_visible+sleep_visible)
+            optimizer(cost = cost, parameters = all_params, constants = wake_visible+sleep_visible)
 
             if persistent:
-                updates += [(p, s) for p, s in zip(initial_hidden, sleep_hidden)]
-
-            return updates
+                for p, s in zip(initial_hidden, sleep_hidden):
+                    add_update(p, s)
 
         return cd_function
 

--- a/plato/tools/dbn/stacked_dbn.py
+++ b/plato/tools/dbn/stacked_dbn.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from plato.core import symbolic_multi, add_update
+from plato.core import symbolic_multi, add_update, create_shared_variable
 from plato.interfaces.decorators import symbolic_updater, symbolic_simple
 from plato.interfaces.helpers import get_theano_rng, create_shared_variable
 from plato.tools.optimization.optimizers import SimpleGradientDescent

--- a/plato/tools/dtp/demo_difference_target_propagation.py
+++ b/plato/tools/dtp/demo_difference_target_propagation.py
@@ -571,12 +571,9 @@ We try removing biases from Difference Target propagation with RELU units.  This
 causes the explosion to happen every time, and after achieving about 91% score.  We can
 compensate by reducing the learning rate to 0.001, but then it takes forever to converge.
 There's basically no middle ground - if you want a bearable learning rate, you get explosions.
-
 """
 
 
 if __name__ == '__main__':
-
     which_experiment = 'all-norm-relu-dtp'
-
     run_experiment(which_experiment)

--- a/plato/tools/dtp/difference_target_prop_variations.py
+++ b/plato/tools/dtp/difference_target_prop_variations.py
@@ -1,4 +1,5 @@
 from general.numpy_helpers import get_rng
+from plato.core import add_update
 from plato.interfaces.decorators import symbolic_simple, symbolic_updater
 from plato.tools.dtp.difference_target_prop import DifferenceTargetLayer, ITargetPropLayer
 import numpy as np
@@ -66,11 +67,10 @@ class PerceptronLayer(ITargetPropLayer):
         delta_w_rev = out.T.dot(x - recon)
         delta_b_rev = (x - recon).sum(axis = 0)
 
-        return [(self.w, self.w+delta_w), (self.b, self.b+delta_b), (self.w_rev, self.w_rev+delta_w_rev), (self.b_rev, self.b_rev+delta_b_rev)]
-
-        # optimizer = AdaMax(alpha = 0.001)
-        # updates = optimizer.update_from_gradients(parameters = [self.w, self.b, self.w_rev, self.b_rev], gradients = [-delta_w, -delta_b, -delta_w_rev, -delta_b_rev])
-        # return updates
+        add_update(self.w, self.w+delta_w)
+        add_update(self.w, self.w_rev+delta_w_rev)
+        add_update(self.b, self.b+delta_b)
+        add_update(self.b_rev, self.b_rev+delta_b_rev)
 
     def backpropagate_target(self, x, target):
 

--- a/plato/tools/lstm/long_short_term_memory.py
+++ b/plato/tools/lstm/long_short_term_memory.py
@@ -180,11 +180,12 @@ class AutoencodingLSTM(object):
                 outputs_info = [x_init, h_init, c_init],
                 )
 
+            if maintain_state:
+                updates += [(x_init, x_gen[-1]), (h_init, h_gen[-1]), (c_init, c_gen[-1])]
+
             for var, val in updates.items():
                 add_update(var, val)
 
-            if maintain_state:
-                updates += [(x_init, x_gen[-1]), (h_init, h_gen[-1]), (c_init, c_gen[-1])]
             return x_gen[n_primer_steps:],
 
         return generate

--- a/plato/tools/lstm/long_short_term_memory.py
+++ b/plato/tools/lstm/long_short_term_memory.py
@@ -1,4 +1,4 @@
-from plato.core import add_update, symbolic_multi, symbolic_simple
+from plato.core import add_update, symbolic_multi, symbolic_simple, create_shared_variable
 from plato.interfaces.decorators import symbolic_updater
 from plato.interfaces.helpers import create_shared_variable, get_theano_rng, get_named_activation_function
 from plato.tools.optimization.cost import mean_xe

--- a/plato/tools/lstm/test_long_short_term_memory.py
+++ b/plato/tools/lstm/test_long_short_term_memory.py
@@ -1,5 +1,6 @@
 from plato.tools.lstm.long_short_term_memory import AutoencodingLSTM
 from plato.tools.optimization.optimizers import AdaMax
+import theano
 from utils.bureaucracy import minibatch_iterate
 from utils.datasets.bounce_data import get_bounce_data
 import numpy as np
@@ -15,7 +16,7 @@ def test_autoencoding_lstm(
         seed = 1234):
 
     data = get_bounce_data(width=width)
-    encoder = OneHotEncoding(n_classes=width, dtype = np.float32)
+    encoder = OneHotEncoding(n_classes=width, dtype = theano.config.floatX)
     onehot_data = encoder(data)
     rng = np.random.RandomState(seed)
     aelstm = AutoencodingLSTM(n_input = 8, n_hidden=50, initializer_fcn = lambda shape: 0.01*rng.randn(*shape))

--- a/plato/tools/mlp/mlp.py
+++ b/plato/tools/mlp/mlp.py
@@ -1,7 +1,7 @@
 from general.numpy_helpers import get_rng
 from general.should_be_builtins import bad_value
-from plato.interfaces.decorators import symbolic_simple
-from plato.interfaces.helpers import get_named_activation_function, create_shared_variable, batch_normalize
+from plato.interfaces.helpers import get_named_activation_function, batch_normalize
+from plato.core import create_shared_variable, symbolic_simple
 from plato.interfaces.interfaces import IParameterized
 import theano.tensor as tt
 import numpy as np

--- a/plato/tools/mlp/mlp.py
+++ b/plato/tools/mlp/mlp.py
@@ -1,7 +1,7 @@
 from general.numpy_helpers import get_rng
 from general.should_be_builtins import bad_value
 from plato.interfaces.decorators import symbolic_simple
-from plato.interfaces.helpers import get_named_activation_function, create_shared_variable
+from plato.interfaces.helpers import get_named_activation_function, create_shared_variable, batch_normalize
 from plato.interfaces.interfaces import IParameterized
 import theano.tensor as tt
 import numpy as np
@@ -34,13 +34,13 @@ class MultiLayerPerceptron(IParameterized):
             Layer(
                 linear_transform = FullyConnectedTransform(
                     w = w,
-                    normalize_minibatch=normalize_minibatch,
+                    normalize_minibatch = normalize_minibatch if layer_no<(n_layers-1) else None,
                     scale = scale_param,
                     use_bias = use_bias
                     ),
                 nonlinearity = nonlinearity
                 )
-            for w, nonlinearity in zip(weights, [hidden_activation] * (n_layers-1) + [output_activation])
+            for w, nonlinearity, layer_no in zip(weights, [hidden_activation] * (n_layers-1) + [output_activation], xrange(n_layers))
             ]
 
     def __call__(self, x):
@@ -52,8 +52,8 @@ class MultiLayerPerceptron(IParameterized):
     def parameters(self):
         return sum([l.parameters for l in self.layers], [])
 
-    @staticmethod
-    def from_init(w_init, layer_sizes, rng=None, last_layer_zero=False, **init_args):
+    @classmethod
+    def from_init(cls, w_init, layer_sizes, rng=None, last_layer_zero=False, **init_args):
         """
         :param w_init: Can be:
             - A scalar, in which case w_init will be interpreted as the standard deviation for the Normally distributed initial weights.
@@ -73,7 +73,7 @@ class MultiLayerPerceptron(IParameterized):
         weights = [w_init(n_in, n_out) for n_in, n_out in zip(layer_sizes[:-1], layer_sizes[1:])]
         if last_layer_zero:
             weights[-1][:] = 0
-        return MultiLayerPerceptron(weights=weights, **init_args)
+        return cls(weights=weights, **init_args)
 
 
 @symbolic_simple
@@ -129,13 +129,15 @@ class FullyConnectedTransform(IParameterized):
         self.w = create_shared_variable(w, name = 'w')
         self.b = create_shared_variable(b, shape = w.shape[1] if w.ndim==2 else (w.shape[0], w.shape[2]) if w.ndim==3 else bad_value(w.shape), name = 'b')
         self.log_scale = create_shared_variable(0 if scale else None, shape = w.shape[1], name = 'log_scale') if scale else None
-        self._normalize_minibatch = normalize_minibatch
+        self.normalizer = \
+            batch_normalize if normalize_minibatch is True else \
+            None if normalize_minibatch is False else \
+            normalize_minibatch
         self._use_bias = use_bias
 
     def __call__(self, x):
         current = x.flatten(2).dot(self.w)
-        if self._normalize_minibatch:
-            current = (current - current.mean(axis = 0, keepdims = True)) / (current.std(axis = 0, keepdims = True) + 1e-9)
+        current = self.normalizer(current) if self.normalizer is not None else current
         if self.log_scale is not None:
             current = current * tt.exp(self.log_scale)
         y = (current + self.b) if self._use_bias else current

--- a/plato/tools/mlp/modified_mlps.py
+++ b/plato/tools/mlp/modified_mlps.py
@@ -1,152 +1,24 @@
-from general.numpy_helpers import get_rng
-from general.should_be_builtins import bad_value
-from plato.core import symbolic_single_output_updater
-from plato.interfaces.helpers import create_shared_variable, batch_normalize, get_named_activation_function
-from plato.interfaces.interfaces import IParameterized
-from plato.tools.misc.tdb_plotting import tdbplot
-import theano
-import theano.tensor as tt
-import numpy as np
+from plato.core import symbolic_simple
+from plato.tools.mlp.mlp import MultiLayerPerceptron
 
 __author__ = 'peter'
 
 
-@symbolic_single_output_updater
-class StatefulMultiLayerPerceptron(object):
+@symbolic_simple
+class SequentialMultiLayerPerceptron(MultiLayerPerceptron):
     """
-    A Multi-Layer Perceptron.  This version is deprecated.  Use plato.tools.mlp.MultiLayerPerceptron, which has a
-    new constructor format.
+    This variant on a multi-layer perceptron processes samples in sequence rather than
+    as a big batch operation.  The only time this will make a difference is when layers
+    have some internal state that they want to update.
     """
-
-    def __init__(self, weights, hidden_activation = 'sig', output_activation = 'sig',
-            normalize_minibatch = False, scale_param = False, use_bias = True):
-        """
-        :param layer_sizes: A list indicating the sizes of each layer, including the input layer.
-        :param hidden_activation: A string or list of strings indicating the type of each hidden layer.
-            {'sig', 'tanh', 'rect-lin', 'lin', 'softmax'}
-        :param output_activation: A string (see above) identifying the activation function for the output layer
-        :param w_init: A function which, given input dims, output dims, return
-        """
-
-        assert all(w_in.shape[-1]==w_out.shape[-2] for w_in, w_out in zip(weights[:-1], weights[1:]))
-        n_layers = len(weights)
-
-        self.layers = [
-            StatefulLayer(
-                linear_transform = StatefulFullyConnectedTransform(
-                    w = w,
-                    normalize_minibatch=normalize_minibatch if layer_no<(n_layers-1) else None,  # It makes no sense to do this to the last layer, because we'll never be able to hit the target unless it too is normalized.
-                    scale = scale_param,
-                    use_bias = use_bias
-                    ),
-                nonlinearity = nonlinearity
-                )
-            for w, nonlinearity, layer_no in zip(weights, [hidden_activation] * (n_layers-1) + [output_activation], xrange(n_layers))
-            ]
 
     def __call__(self, x):
-        outputs, updates = theano.scan(
-            fn = self.process_sample,
-            sequences = [x[:, None, :]],
-            )
-        return outputs[:, 0, :], updates
+        output = self.process_sample.scan(sequences = [x[:, None, :]])
+        return output[:, 0, :]
 
+    @symbolic_simple
     def process_sample(self, x):
-        assert x.tag.test_value.shape[0] == 1, "We expect x to have a minibatch of size 1."
-        all_updates = []
+        assert x.ishape[0] == 1, "We expect x to have a minibatch of size 1."
         for lay in self.layers:
-            x, updates = lay.to_format(symbolic_single_output_updater)(x)
-            all_updates+=updates
-        return x, all_updates
-
-
-    @property
-    def parameters(self):
-        return sum([l.parameters for l in self.layers], [])
-
-    @staticmethod
-    def from_init(w_init_mag, layer_sizes, rng=None, last_layer_zero=False, **init_args):
-        rng = get_rng(rng)
-        weights = [w_init_mag*rng.randn(n_in, n_out) for n_in, n_out in zip(layer_sizes[:-1], layer_sizes[1:])]
-        if last_layer_zero:
-            weights[-1][:] = 0
-        return StatefulMultiLayerPerceptron(weights=weights, **init_args)
-
-
-@symbolic_single_output_updater
-class StatefulLayer(IParameterized):
-    """
-    The composition of a linear transform and a nonlinearity.
-    """
-
-    def __init__(self, linear_transform, nonlinearity):
-        """
-        linear_transform: Can be:
-            A callable (e.g. FullyConnectedBridge/ConvolutionalBridge) which does a linear transform on the data.
-            A numpy array - in which case it will be used to instantiate a linear transform.
-        """
-        if isinstance(linear_transform, np.ndarray):
-            assert (linear_transform.ndim == 2 and nonlinearity!='maxout') or (linear_transform.ndim == 3 and nonlinearity=='maxout'), \
-                'Your weight matrix must be 2-D (or 3-D if you have maxout units)'
-            linear_transform = StatefulFullyConnectedTransform(w=linear_transform)
-        if isinstance(nonlinearity, str):
-            nonlinearity = get_named_activation_function(nonlinearity)
-        self.linear_transform = linear_transform
-        self.nonlinearity = nonlinearity
-
-    def __call__(self, x):
-        pre_sig, state_updates = self.linear_transform(x)
-        return self.nonlinearity(pre_sig), state_updates
-
-    @property
-    def parameters(self):
-        return self.linear_transform.parameters
-
-
-@symbolic_single_output_updater
-class StatefulFullyConnectedTransform(IParameterized):
-    """
-    An element which multiplies the input by some weight matrix w and adds a bias.
-    """
-
-    def __init__(self, w, b = 0, normalize_minibatch = False, scale = False, use_bias = True):
-        """
-        :param w: Initial weight value.  Can be:
-            - A numpy array, in which case a shared variable is instantiated from this data.
-            - A symbolic variable that is either a shared variabe or descended from a shared variable.
-              This is used when there are shared parameters.
-        :param b: Can be:
-            - A numpy vector representing the initial bias on the hidden layer, where len(b) = w.shape[1]
-            - A scaler, which just initializes the full vector to this value
-        :param normalize_minibatch: Set to True to normalize over the minibatch.  This has been shown to cause better optimization
-        :param scale: Set to True to include an scale term (per output).  Generally this only makes sense if
-            normalize_minibatch is True.
-        :param use_bias: Use a bias term?  Generally, the answer is "True", a bias term helps.
-        """
-        self.w = create_shared_variable(w, name = 'w')
-        self.b = create_shared_variable(b, shape = w.shape[1] if w.ndim==2 else (w.shape[0], w.shape[2]) if w.ndim==3 else bad_value(w.shape), name = 'b')
-        self.log_scale = create_shared_variable(0 if scale else None, shape = w.shape[1], name = 'log_scale') if scale else None
-        self.normalizer = \
-            batch_normalize if normalize_minibatch is True else \
-            None if normalize_minibatch is False else \
-            normalize_minibatch
-        self._use_bias = use_bias
-
-        # tdbplot(self.w, 'w-%s'%self)
-
-    def __call__(self, x):
-        current = x.flatten(2).dot(self.w)
-
-        if self.normalizer is not None:
-            current, normalization_updates = self.normalizer.to_format(symbolic_single_output_updater)(current)
-        else:
-            normalization_updates = []
-
-        if self.log_scale is not None:
-            current = current * tt.exp(self.log_scale)
-        y = (current + self.b) if self._use_bias else current
-        return y, normalization_updates
-
-    @property
-    def parameters(self):
-        return [self.w] + ([self.b] if self._use_bias else []) + ([self.log_scale] if self.log_scale is not None else [])
+            x = lay(x)
+        return x

--- a/plato/tools/mlp/modified_mlps.py
+++ b/plato/tools/mlp/modified_mlps.py
@@ -1,0 +1,152 @@
+from general.numpy_helpers import get_rng
+from general.should_be_builtins import bad_value
+from plato.core import symbolic_single_output_updater
+from plato.interfaces.helpers import create_shared_variable, batch_normalize, get_named_activation_function
+from plato.interfaces.interfaces import IParameterized
+from plato.tools.misc.tdb_plotting import tdbplot
+import theano
+import theano.tensor as tt
+import numpy as np
+
+__author__ = 'peter'
+
+
+@symbolic_single_output_updater
+class StatefulMultiLayerPerceptron(object):
+    """
+    A Multi-Layer Perceptron.  This version is deprecated.  Use plato.tools.mlp.MultiLayerPerceptron, which has a
+    new constructor format.
+    """
+
+    def __init__(self, weights, hidden_activation = 'sig', output_activation = 'sig',
+            normalize_minibatch = False, scale_param = False, use_bias = True):
+        """
+        :param layer_sizes: A list indicating the sizes of each layer, including the input layer.
+        :param hidden_activation: A string or list of strings indicating the type of each hidden layer.
+            {'sig', 'tanh', 'rect-lin', 'lin', 'softmax'}
+        :param output_activation: A string (see above) identifying the activation function for the output layer
+        :param w_init: A function which, given input dims, output dims, return
+        """
+
+        assert all(w_in.shape[-1]==w_out.shape[-2] for w_in, w_out in zip(weights[:-1], weights[1:]))
+        n_layers = len(weights)
+
+        self.layers = [
+            StatefulLayer(
+                linear_transform = StatefulFullyConnectedTransform(
+                    w = w,
+                    normalize_minibatch=normalize_minibatch if layer_no<(n_layers-1) else None,  # It makes no sense to do this to the last layer, because we'll never be able to hit the target unless it too is normalized.
+                    scale = scale_param,
+                    use_bias = use_bias
+                    ),
+                nonlinearity = nonlinearity
+                )
+            for w, nonlinearity, layer_no in zip(weights, [hidden_activation] * (n_layers-1) + [output_activation], xrange(n_layers))
+            ]
+
+    def __call__(self, x):
+        outputs, updates = theano.scan(
+            fn = self.process_sample,
+            sequences = [x[:, None, :]],
+            )
+        return outputs[:, 0, :], updates
+
+    def process_sample(self, x):
+        assert x.tag.test_value.shape[0] == 1, "We expect x to have a minibatch of size 1."
+        all_updates = []
+        for lay in self.layers:
+            x, updates = lay.to_format(symbolic_single_output_updater)(x)
+            all_updates+=updates
+        return x, all_updates
+
+
+    @property
+    def parameters(self):
+        return sum([l.parameters for l in self.layers], [])
+
+    @staticmethod
+    def from_init(w_init_mag, layer_sizes, rng=None, last_layer_zero=False, **init_args):
+        rng = get_rng(rng)
+        weights = [w_init_mag*rng.randn(n_in, n_out) for n_in, n_out in zip(layer_sizes[:-1], layer_sizes[1:])]
+        if last_layer_zero:
+            weights[-1][:] = 0
+        return StatefulMultiLayerPerceptron(weights=weights, **init_args)
+
+
+@symbolic_single_output_updater
+class StatefulLayer(IParameterized):
+    """
+    The composition of a linear transform and a nonlinearity.
+    """
+
+    def __init__(self, linear_transform, nonlinearity):
+        """
+        linear_transform: Can be:
+            A callable (e.g. FullyConnectedBridge/ConvolutionalBridge) which does a linear transform on the data.
+            A numpy array - in which case it will be used to instantiate a linear transform.
+        """
+        if isinstance(linear_transform, np.ndarray):
+            assert (linear_transform.ndim == 2 and nonlinearity!='maxout') or (linear_transform.ndim == 3 and nonlinearity=='maxout'), \
+                'Your weight matrix must be 2-D (or 3-D if you have maxout units)'
+            linear_transform = StatefulFullyConnectedTransform(w=linear_transform)
+        if isinstance(nonlinearity, str):
+            nonlinearity = get_named_activation_function(nonlinearity)
+        self.linear_transform = linear_transform
+        self.nonlinearity = nonlinearity
+
+    def __call__(self, x):
+        pre_sig, state_updates = self.linear_transform(x)
+        return self.nonlinearity(pre_sig), state_updates
+
+    @property
+    def parameters(self):
+        return self.linear_transform.parameters
+
+
+@symbolic_single_output_updater
+class StatefulFullyConnectedTransform(IParameterized):
+    """
+    An element which multiplies the input by some weight matrix w and adds a bias.
+    """
+
+    def __init__(self, w, b = 0, normalize_minibatch = False, scale = False, use_bias = True):
+        """
+        :param w: Initial weight value.  Can be:
+            - A numpy array, in which case a shared variable is instantiated from this data.
+            - A symbolic variable that is either a shared variabe or descended from a shared variable.
+              This is used when there are shared parameters.
+        :param b: Can be:
+            - A numpy vector representing the initial bias on the hidden layer, where len(b) = w.shape[1]
+            - A scaler, which just initializes the full vector to this value
+        :param normalize_minibatch: Set to True to normalize over the minibatch.  This has been shown to cause better optimization
+        :param scale: Set to True to include an scale term (per output).  Generally this only makes sense if
+            normalize_minibatch is True.
+        :param use_bias: Use a bias term?  Generally, the answer is "True", a bias term helps.
+        """
+        self.w = create_shared_variable(w, name = 'w')
+        self.b = create_shared_variable(b, shape = w.shape[1] if w.ndim==2 else (w.shape[0], w.shape[2]) if w.ndim==3 else bad_value(w.shape), name = 'b')
+        self.log_scale = create_shared_variable(0 if scale else None, shape = w.shape[1], name = 'log_scale') if scale else None
+        self.normalizer = \
+            batch_normalize if normalize_minibatch is True else \
+            None if normalize_minibatch is False else \
+            normalize_minibatch
+        self._use_bias = use_bias
+
+        # tdbplot(self.w, 'w-%s'%self)
+
+    def __call__(self, x):
+        current = x.flatten(2).dot(self.w)
+
+        if self.normalizer is not None:
+            current, normalization_updates = self.normalizer.to_format(symbolic_single_output_updater)(current)
+        else:
+            normalization_updates = []
+
+        if self.log_scale is not None:
+            current = current * tt.exp(self.log_scale)
+        y = (current + self.b) if self._use_bias else current
+        return y, normalization_updates
+
+    @property
+    def parameters(self):
+        return [self.w] + ([self.b] if self._use_bias else []) + ([self.log_scale] if self.log_scale is not None else [])

--- a/plato/tools/mlp/test_mlp.py
+++ b/plato/tools/mlp/test_mlp.py
@@ -36,8 +36,7 @@ def test_bare_bones_mlp(seed = 1234):
     def train(x, y):
         output = mlp(x)
         cost = negative_log_likelihood_dangerous(output, y)
-        updates = optimizer(cost, mlp.parameters)
-        return updates
+        optimizer(cost, mlp.parameters)
 
     train_fcn = train.compile()
 

--- a/plato/tools/mlp/test_modified_mlps.py
+++ b/plato/tools/mlp/test_modified_mlps.py
@@ -1,6 +1,6 @@
 from plato.interfaces.helpers import SlowBatchNormalize
 from plato.tools.common.online_predictors import GradientBasedPredictor
-from plato.tools.mlp.modified_mlps import StatefulMultiLayerPerceptron
+from plato.tools.mlp.modified_mlps import SequentialMultiLayerPerceptron
 from plato.tools.optimization.optimizers import GradientDescent
 from utils.predictors.predictor_tests import assert_online_predictor_not_broken
 
@@ -12,9 +12,9 @@ def test_online_minibatch_normalization():
     assert_online_predictor_not_broken(
         predictor_constructor = lambda n_dim_in, n_dim_out:
             GradientBasedPredictor(
-                function = StatefulMultiLayerPerceptron.from_init(
+                function = SequentialMultiLayerPerceptron.from_init(
                     normalize_minibatch = SlowBatchNormalize(20),
-                    output_activation = 'linear', hidden_activation = 'relu', layer_sizes=[n_dim_in, 50, n_dim_out], w_init_mag = 0.1, use_bias=False, rng=1234),
+                    output_activation = 'linear', hidden_activation = 'relu', layer_sizes=[n_dim_in, 50, n_dim_out], w_init = 0.1, use_bias=False, rng=1234),
                 cost_function = 'mse',
                 optimizer=GradientDescent(eta=0.01)
                 ).compile(),

--- a/plato/tools/mlp/test_modified_mlps.py
+++ b/plato/tools/mlp/test_modified_mlps.py
@@ -1,0 +1,29 @@
+from plato.interfaces.helpers import SlowBatchNormalize
+from plato.tools.common.online_predictors import GradientBasedPredictor
+from plato.tools.mlp.modified_mlps import StatefulMultiLayerPerceptron
+from plato.tools.optimization.optimizers import GradientDescent
+from utils.predictors.predictor_tests import assert_online_predictor_not_broken
+
+__author__ = 'peter'
+
+
+def test_online_minibatch_normalization():
+
+    assert_online_predictor_not_broken(
+        predictor_constructor = lambda n_dim_in, n_dim_out:
+            GradientBasedPredictor(
+                function = StatefulMultiLayerPerceptron.from_init(
+                    normalize_minibatch = SlowBatchNormalize(20),
+                    output_activation = 'linear', hidden_activation = 'relu', layer_sizes=[n_dim_in, 50, n_dim_out], w_init_mag = 0.1, use_bias=False, rng=1234),
+                cost_function = 'mse',
+                optimizer=GradientDescent(eta=0.01)
+                ).compile(),
+        categorical_target=False,
+        minibatch_size=1,
+        n_epochs=3,
+        initial_score_under = 50
+        )
+
+
+if __name__ == '__main__':
+    test_online_minibatch_normalization()

--- a/plato/tools/optimization/optimizers.py
+++ b/plato/tools/optimization/optimizers.py
@@ -25,7 +25,7 @@ class UniformParameterOptimizer(IGradientOptimizer):
 
     def __call__(self, cost, parameters, constants = []):
         gradients = theano.grad(cost, parameters, consider_constant = constants)  # Can be faster than [theano.grad(p) for p in parameters]
-        return self.update_from_gradients(parameters, gradients)
+        self.update_from_gradients(parameters, gradients)
 
     @symbolic_updater
     def update_from_gradients(self, parameters, gradients):
@@ -36,8 +36,6 @@ class UniformParameterOptimizer(IGradientOptimizer):
         assert len(parameters)==len(gradients), 'Lenght of parameter vector must match length of gradients.'
         for p, g in zip(parameters, gradients):
             self._update_param(p, g)
-
-        # return sum([self._update_param(p, g) for p, g in zip(parameters, gradients)], [])
 
     @abstractmethod
     def _update_param(self, param, gradient):
@@ -68,7 +66,6 @@ class SimpleGradientDescent(UniformParameterOptimizer):
 
     def _update_param(self, param, gradient):
         add_update(param, param - self._eta * gradient)
-        # return [(param, param - self._eta * gradient)]
 
 
 class AdaMax(UniformParameterOptimizer):

--- a/plato/tools/optimization/optimizers.py
+++ b/plato/tools/optimization/optimizers.py
@@ -49,7 +49,6 @@ class GradientStepUpdater(UniformParameterOptimizer):
     """
     def _update_param(self, param, gradient):
         add_update(param, param - gradient)
-        # return [(param, param - gradient)]
 
 
 class SimpleGradientDescent(UniformParameterOptimizer):
@@ -79,14 +78,12 @@ class AdaMax(UniformParameterOptimizer):
     def _update_param(self, param, gradient):
         mom1 = theano.shared(np.zeros_like(param.get_value()))
         mom2 = theano.shared(np.zeros_like(param.get_value()))
-        # gradient = theano.grad(cost, param, consider_constant = constants)
         mom1_new = mom1 + self._beta_1 * (gradient - mom1)
         mom2_new = tt.maximum(abs(gradient) + self._eps, (1. - self._beta_2) * mom2)
         new_param = param - self._alpha * mom1_new / mom2_new
         add_update(param, new_param)
         add_update(mom1, mom1_new)
         add_update(mom2, mom2_new)
-        # return updates
 
 
 class RMSProp(UniformParameterOptimizer):
@@ -102,7 +99,6 @@ class RMSProp(UniformParameterOptimizer):
         delta_p = - self.learning_rate * gradient / tt.maximum(tt.sqrt(new_mean_squared_grad), self.epsilon)
         add_update(param, param + delta_p)
         add_update(mean_squared_grad, new_mean_squared_grad)
-        # return [(param, param + delta_p), (mean_squared_grad, new_mean_squared_grad)]
 
 
 class AdaGrad(UniformParameterOptimizer):
@@ -124,10 +120,8 @@ class AdaGrad(UniformParameterOptimizer):
         sum_squared_grad = theano.shared(param.get_value()*0)
         new_ssg = (1-self.decay_rate)*sum_squared_grad + gradient**2
         scale = tt.maximum(self.eps, tt.sqrt(new_ssg))
-        new_param = param - (self.learning_rate / scale) * gradient
-        add_update(param, new_param)
+        add_update(param, param - (self.learning_rate / scale) * gradient)
         add_update(sum_squared_grad, new_ssg)
-        # return [(param, new_param), (sum_squared_grad, new_ssg)]
 
 
 class GradientDescent(UniformParameterOptimizer):
@@ -146,15 +140,11 @@ class GradientDescent(UniformParameterOptimizer):
         if self.momentum != 0:
             mom = theano.shared(np.zeros_like(param.get_value()))
             new_mom = self.momentum * mom + gradient
-            # momentum_updates = [(mom, new_mom)]
             add_update(mom, new_mom)
             direction = new_mom  # Or mom, something about Nesterov...
         else:
             direction = gradient
-            # momentum_updates = []
-
         add_update(param, param - self.eta*direction - self.decay*param)
-        # return [(param, param - self.eta*direction - self.decay*param)] + momentum_updates
 
 
 class MultiplicativeGradientDescent(UniformParameterOptimizer):
@@ -165,7 +155,6 @@ class MultiplicativeGradientDescent(UniformParameterOptimizer):
     def _update_param(self, param, gradient):
         multiplier = tt.exp(-tt.tanh(gradient)*self.factor)
         add_update(param, param*multiplier)
-        # return [(param, param*multiplier)]
 
 
 def get_named_optimizer(name, learning_rate):

--- a/plato/tools/optimization/sampling.py
+++ b/plato/tools/optimization/sampling.py
@@ -1,7 +1,8 @@
 from abc import abstractmethod
 
 import numpy as np
-from plato.interfaces.decorators import symbolic_simple, symbolic_standard
+from plato.core import symbolic_multi, add_update
+from plato.interfaces.decorators import symbolic_simple
 from plato.interfaces.helpers import get_theano_rng
 from plato.tools.common.basic import softmax
 import theano
@@ -172,7 +173,7 @@ class IIndexGenerator(object):
             updates contains whatever state updates are required.
         """
 
-@symbolic_standard
+@symbolic_multi
 class BaseIndexGenerator(IIndexGenerator):
 
     def __init__(self, size):
@@ -184,7 +185,9 @@ class BaseIndexGenerator(IIndexGenerator):
         full_indices = \
             (vector_ixs, ) if isinstance(self._size, int) else \
             ind2sub(vector_ixs, self._size)
-        return full_indices, updates
+        for var, val in updates:
+            add_update(var, val)
+        return full_indices
 
     @abstractmethod
     def _get_vector_indices_and_updates(self):

--- a/plato/tools/rbm/rbm_parts.py
+++ b/plato/tools/rbm/rbm_parts.py
@@ -1,7 +1,5 @@
-from plato.core import symbolic_simple
-from plato.interfaces.helpers import initialize_param, create_shared_variable
+from plato.core import symbolic_simple, initialize_param, create_shared_variable
 from plato.interfaces.interfaces import IParameterized, IFreeEnergy
-from theano import tensor as tt
 import theano
 import theano.tensor as tt
 from theano.tensor.shared_randomstreams import RandomStreams

--- a/plato/tools/rbm/restricted_boltzmann_machine.py
+++ b/plato/tools/rbm/restricted_boltzmann_machine.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 
 import numpy as np
 from plato.core import add_update, symbolic_multi
-from plato.interfaces.decorators import symbolic_updater, symbolic_simple, symbolic_standard, SymbolicReturn
+from plato.interfaces.decorators import symbolic_updater, symbolic_simple
 from plato.tools.optimization.optimizers import SimpleGradientDescent
 import theano
 import theano.tensor as tt
@@ -56,10 +56,11 @@ def simple_rbm(visible_layer, bridge, hidden_layer):
         persistent_state = theano.shared((init_visible_state if init_hidden_state is None else init_hidden_state).astype(theano.config.floatX),
             name = 'persistent_%s_state' % start_from)
 
-        @symbolic_standard
+        @symbolic_multi
         def free_sample():
             (visible_state, hidden_state), _ = get_bounce_fcn(start_from=start_from, n_steps = n_steps, return_smooth_visible = return_smooth_visible)(persistent_state)
-            return (visible_state, hidden_state), [(persistent_state, visible_state if start_from == 'visible' else hidden_state)]
+            add_update(persistent_state, visible_state if start_from == 'visible' else hidden_state)
+            return visible_state, hidden_state
         return free_sample
 
     def get_bounce_fcn(start_from = 'visible', n_steps = 1, return_smooth_visible = False):

--- a/plato/tools/regressors/online_regressor.py
+++ b/plato/tools/regressors/online_regressor.py
@@ -47,8 +47,7 @@ class OnlineRegressor(ISymbolicPredictor, IParameterized):
         """
         y = self.predict(x)
         cost = self.cost_fcn(y, targets)
-        updates = self.optimizer(cost = cost, parameters = self.parameters)
-        return updates
+        self.optimizer(cost = cost, parameters = self.parameters)
 
     @property
     def parameters(self):

--- a/plato/tools/va/gaussian_variational_autoencoder.py
+++ b/plato/tools/va/gaussian_variational_autoencoder.py
@@ -65,8 +65,7 @@ class GaussianVariationalAutoencoder(object):
         :return: A list of training updates
         """
         lower_bound = self.compute_lower_bound(x_samples)
-        updates = self.optimizer(cost = -lower_bound, parameters = self.parameters)
-        return updates
+        self.optimizer(cost = -lower_bound, parameters = self.parameters)
 
     @symbolic_simple
     def compute_lower_bound(self, x_samples):

--- a/plato/tools/va/variational_autoencoder.py
+++ b/plato/tools/va/variational_autoencoder.py
@@ -184,11 +184,11 @@ class DistributionMLP(IParameterized):
     def __call__(self, x):
 
         if self.distribution == 'gaussian':
-            (mu, log_sigma), _ = self.chain(x)
+            (mu, log_sigma) = self.chain(x)
             dist = MultipleDiagonalGaussianDistribution(mu, sigma_sq = tt.exp(log_sigma)**2)
 
         elif self.distribution == 'bernoulli':
-            (p, ), _ = self.chain(x)
+            (p, ) = self.chain(x)
             dist = MultipleBernoulliDistribution(p)
         return dist
 

--- a/plato/tools/va/variational_autoencoder.py
+++ b/plato/tools/va/variational_autoencoder.py
@@ -41,8 +41,7 @@ class VariationalAutoencoder(object):
         z_samples = z_dist.sample(1, self.rng)[0]  # Just one sample per data point.  Shape (minibatch_size, n_dims)
         x_dist = self.pq_pair.p_x_given_z(z_samples)
         lower_bound = -z_dist.kl_divergence(self.pq_pair.prior) + x_dist.log_prob(x_samples) # (minibatch_size, )
-        updates = self.optimizer(cost = -lower_bound.mean(), parameters = self.parameters)
-        return updates
+        self.optimizer(cost = -lower_bound.mean(), parameters = self.parameters)
 
     @symbolic_simple
     def sample(self, n_samples):

--- a/plato_environment.py
+++ b/plato_environment.py
@@ -15,7 +15,7 @@ import matplotlib
 import matplotlib.pyplot as plt
 import theano
 import theano.tensor as tt
-from plato.interfaces.decorators import symbolic_simple, symbolic_standard, symbolic_updater
+from plato.interfaces.decorators import symbolic_simple, symbolic_stateless, symbolic_multi, symbolic_updater
 import plato.tools.all as pt
 from plotting.live_plotting import LiveStream, LiveCanal
 from plotting.easy_plotting import ezplot

--- a/plato_tutorial.html
+++ b/plato_tutorial.html
@@ -177,7 +177,7 @@ div#notebook {
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<h1 id="Plato-Tutorial">Plato Tutorial<a class="anchor-link" href="#Plato-Tutorial">&#182;</a></h1><p>Plato is a python package built on top of <a href="http://deeplearning.net/software/theano/">Theano</a> with two objectives:<br>
+<h1 id="Plato-Tutorial">Plato Tutorial<a class="anchor-link" href="#Plato-Tutorial">&#182;</a></h1><p><a href="https://github.com/petered/plato">Plato</a> is a python package built on top of <a href="http://deeplearning.net/software/theano/">Theano</a> with two objectives:<br>
 1) Simplify the use of Theano.<br>
 2) Build a good libary of standard Deep Learning algorithms.</p>
 <p>This tutorial takes you throught the Plato API.  It's useful but not necessary to have a basic knowledge of Theano to do this tutorial.</p>
@@ -197,17 +197,17 @@ div#notebook {
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[3]:</div>
+<div class="prompt input_prompt">In&nbsp;[7]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython3"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="k">import</span> <span class="n">symbolic</span>
+<div class=" highlight hl-ipython2"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic</span>
 
 <span class="nd">@symbolic</span>
 <span class="k">def</span> <span class="nf">add_two_numbers</span><span class="p">(</span><span class="n">x</span><span class="p">,</span> <span class="n">y</span><span class="p">):</span>
     <span class="k">return</span> <span class="n">x</span><span class="o">+</span><span class="n">y</span>
 
 <span class="n">f</span> <span class="o">=</span> <span class="n">add_two_numbers</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
-<span class="nb">print</span> <span class="s">&#39;3+4=%s&#39;</span> <span class="o">%</span> <span class="n">f</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="mi">4</span><span class="p">)</span>
+<span class="k">print</span> <span class="s">&#39;3+4=</span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="n">f</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="mi">4</span><span class="p">)</span>
 </pre></div>
 
 </div>
@@ -241,18 +241,18 @@ div#notebook {
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[9]:</div>
+<div class="prompt input_prompt">In&nbsp;[1]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython3"><pre><span class="kn">import</span> <span class="nn">theano</span>
-<span class="kn">from</span> <span class="nn">theano.tensor</span> <span class="k">import</span> <span class="n">scalar</span>
+<div class=" highlight hl-ipython2"><pre><span class="kn">import</span> <span class="nn">theano</span>
+<span class="kn">from</span> <span class="nn">theano.tensor</span> <span class="kn">import</span> <span class="n">scalar</span>
 
 <span class="n">x</span> <span class="o">=</span> <span class="n">scalar</span><span class="p">(</span><span class="n">dtype</span> <span class="o">=</span> <span class="s">&#39;int32&#39;</span><span class="p">)</span>
 <span class="n">y</span> <span class="o">=</span> <span class="n">scalar</span><span class="p">(</span><span class="n">dtype</span> <span class="o">=</span> <span class="s">&#39;int32&#39;</span><span class="p">)</span>
 <span class="n">z</span> <span class="o">=</span> <span class="n">x</span><span class="o">+</span><span class="n">y</span>
 
 <span class="n">f</span> <span class="o">=</span> <span class="n">theano</span><span class="o">.</span><span class="n">function</span><span class="p">(</span><span class="n">inputs</span> <span class="o">=</span> <span class="p">[</span><span class="n">x</span><span class="p">,</span> <span class="n">y</span><span class="p">],</span> <span class="n">outputs</span> <span class="o">=</span> <span class="n">z</span><span class="p">)</span>
-<span class="nb">print</span> <span class="s">&#39;3+4=%s&#39;</span> <span class="o">%</span> <span class="n">f</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="mi">4</span><span class="p">)</span>
+<span class="k">print</span> <span class="s">&#39;3+4=</span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="n">f</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="mi">4</span><span class="p">)</span>
 </pre></div>
 
 </div>
@@ -266,16 +266,6 @@ div#notebook {
 <div class="output_area"><div class="prompt"></div>
 <div class="output_subarea output_stream output_stdout output_text">
 <pre>3+4=7
-</pre>
-</div>
-</div>
-
-<div class="output_area"><div class="prompt"></div>
-<div class="output_subarea output_stream output_stderr output_text">
-<pre>/Users/peter/projects/argmaxlab/venv/src/theano/theano/tensor/var.py:128: UserWarning: Warning, Cannot compute test value: input 0 (&lt;TensorType(int32, scalar)&gt;) of Op Elemwise{add,no_inplace}(&lt;TensorType(int32, scalar)&gt;, &lt;TensorType(int32, scalar)&gt;) missing default value
-  return theano.tensor.basic.add(self, other)
-/Users/peter/projects/argmaxlab/venv/src/theano/theano/tensor/var.py:128: UserWarning: Warning, Cannot compute test value: input 1 (&lt;TensorType(int32, scalar)&gt;) of Op Elemwise{add,no_inplace}(&lt;TensorType(int32, scalar)&gt;, &lt;TensorType(int32, scalar)&gt;) missing default value
-  return theano.tensor.basic.add(self, other)
 </pre>
 </div>
 </div>
@@ -306,24 +296,23 @@ div#notebook {
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[8]:</div>
+<div class="prompt input_prompt">In&nbsp;[2]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython3"><pre><span class="kn">import</span> <span class="nn">theano</span>
-<span class="kn">from</span> <span class="nn">plato.core</span> <span class="k">import</span> <span class="n">symbolic</span><span class="p">,</span> <span class="n">add_update</span>
+<div class=" highlight hl-ipython2"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic</span><span class="p">,</span> <span class="n">add_update</span><span class="p">,</span> <span class="n">create_shared_variable</span>
 
 <span class="nd">@symbolic</span>
 <span class="k">def</span> <span class="nf">counter</span><span class="p">():</span>
-    <span class="n">count</span> <span class="o">=</span> <span class="n">theano</span><span class="o">.</span><span class="n">shared</span><span class="p">(</span><span class="mi">0</span><span class="p">)</span>  <span class="c"># Create a shared variable, initialized at zero, which stores the count.</span>
+    <span class="n">count</span> <span class="o">=</span> <span class="n">create_shared_variable</span><span class="p">(</span><span class="mi">0</span><span class="p">)</span>  <span class="c"># Create a shared variable, initialized at zero, which stores the count.</span>
     <span class="n">new_count</span> <span class="o">=</span> <span class="n">count</span><span class="o">+</span><span class="mi">1</span>
     <span class="n">add_update</span><span class="p">(</span><span class="n">count</span><span class="p">,</span> <span class="n">new_count</span><span class="p">)</span>
     <span class="k">return</span> <span class="n">new_count</span>
 
 <span class="n">f</span> <span class="o">=</span> <span class="n">counter</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
-<span class="nb">print</span> <span class="s">&#39;I can count to ten.  See: %s&#39;</span> <span class="o">%</span> <span class="p">([</span><span class="nb">int</span><span class="p">(</span><span class="n">f</span><span class="p">())</span> <span class="k">for</span> <span class="n">_</span> <span class="ow">in</span> <span class="n">xrange</span><span class="p">(</span><span class="mi">10</span><span class="p">)])</span>
+<span class="k">print</span> <span class="s">&#39;I can count to ten.  See: </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">([</span><span class="nb">int</span><span class="p">(</span><span class="n">f</span><span class="p">())</span> <span class="k">for</span> <span class="n">_</span> <span class="ow">in</span> <span class="nb">xrange</span><span class="p">(</span><span class="mi">10</span><span class="p">)])</span>
 
 <span class="n">f2</span> <span class="o">=</span> <span class="n">counter</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
-<span class="nb">print</span> <span class="s">&#39;I can too: %s&#39;</span> <span class="o">%</span> <span class="p">([</span><span class="nb">int</span><span class="p">(</span><span class="n">f2</span><span class="p">())</span> <span class="k">for</span> <span class="n">_</span> <span class="ow">in</span> <span class="n">xrange</span><span class="p">(</span><span class="mi">10</span><span class="p">)])</span>
+<span class="k">print</span> <span class="s">&#39;I can too: </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">([</span><span class="nb">int</span><span class="p">(</span><span class="n">f2</span><span class="p">())</span> <span class="k">for</span> <span class="n">_</span> <span class="ow">in</span> <span class="nb">xrange</span><span class="p">(</span><span class="mi">10</span><span class="p">)])</span>
 <span class="c"># Note that we start from scratch when we compile the function a new time, </span>
 <span class="c"># because the shared variable is initialized within the function call.  If we</span>
 <span class="c"># had declaired counter outside the function, the second count would run from </span>
@@ -362,16 +351,15 @@ I can too: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[7]:</div>
+<div class="prompt input_prompt">In&nbsp;[3]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython3"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="k">import</span> <span class="n">symbolic</span><span class="p">,</span> <span class="n">add_update</span>
-<span class="kn">import</span> <span class="nn">theano</span>
+<div class=" highlight hl-ipython2"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic</span><span class="p">,</span> <span class="n">add_update</span><span class="p">,</span> <span class="n">create_shared_variable</span>
 
 <span class="k">class</span> <span class="nc">Collatz</span><span class="p">:</span>
 
     <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">initial_value</span><span class="p">):</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">value</span> <span class="o">=</span> <span class="n">theano</span><span class="o">.</span><span class="n">shared</span><span class="p">(</span><span class="n">initial_value</span><span class="p">)</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">value</span> <span class="o">=</span> <span class="n">create_shared_variable</span><span class="p">(</span><span class="n">initial_value</span><span class="p">)</span>
         
     <span class="nd">@symbolic</span>
     <span class="k">def</span> <span class="nf">divide_by_2</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
@@ -390,18 +378,18 @@ I can too: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 <span class="n">mul_fcn</span> <span class="o">=</span> <span class="n">c</span><span class="o">.</span><span class="n">multiply_by_3_and_add_one</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
 
 <span class="n">value</span> <span class="o">=</span> <span class="n">c</span><span class="o">.</span><span class="n">value</span><span class="o">.</span><span class="n">get_value</span><span class="p">()</span>
-<span class="nb">print</span> <span class="s">&#39;Demonstrate Collatz conjecture for initial value of %s&#39;</span> <span class="o">%</span> <span class="n">c</span><span class="o">.</span><span class="n">value</span><span class="o">.</span><span class="n">get_value</span><span class="p">()</span>
+<span class="k">print</span> <span class="s">&#39;Demonstrate Collatz conjecture for initial value of </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="n">c</span><span class="o">.</span><span class="n">value</span><span class="o">.</span><span class="n">get_value</span><span class="p">()</span>
 
 <span class="k">while</span> <span class="n">value</span> <span class="o">!=</span> <span class="mi">1</span><span class="p">:</span>
     <span class="n">value</span> <span class="o">=</span> <span class="n">div_fcn</span><span class="p">()</span> <span class="k">if</span> <span class="n">value</span> <span class="o">%</span> <span class="mi">2</span> <span class="o">==</span> <span class="mi">0</span> <span class="k">else</span> <span class="n">mul_fcn</span><span class="p">()</span>
-    <span class="nb">print</span> <span class="n">value</span>
+    <span class="k">print</span> <span class="n">value</span>
 
-<span class="nb">print</span> <span class="s">&#39;Note that since the value is attached to the instance, it persists if functons are recompiled.&#39;</span>
+<span class="k">print</span> <span class="s">&#39;Note that since the value is attached to the instance, it persists if functons are recompiled.&#39;</span>
 <span class="n">new_div_fcn</span> <span class="o">=</span> <span class="n">c</span><span class="o">.</span><span class="n">divide_by_2</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
 <span class="n">new_mul_fcn</span> <span class="o">=</span> <span class="n">c</span><span class="o">.</span><span class="n">multiply_by_3_and_add_one</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
-<span class="k">for</span> <span class="n">_</span> <span class="ow">in</span> <span class="n">xrange</span><span class="p">(</span><span class="mi">6</span><span class="p">):</span>
+<span class="k">for</span> <span class="n">_</span> <span class="ow">in</span> <span class="nb">xrange</span><span class="p">(</span><span class="mi">6</span><span class="p">):</span>
     <span class="n">value</span> <span class="o">=</span> <span class="n">new_div_fcn</span><span class="p">()</span> <span class="k">if</span> <span class="n">value</span> <span class="o">%</span> <span class="mi">2</span> <span class="o">==</span> <span class="mi">0</span> <span class="k">else</span> <span class="n">new_mul_fcn</span><span class="p">()</span>
-    <span class="nb">print</span> <span class="n">value</span>
+    <span class="k">print</span> <span class="n">value</span>
 </pre></div>
 
 </div>
@@ -449,10 +437,10 @@ Note that since the value is attached to the instance, it persists if functons a
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[6]:</div>
+<div class="prompt input_prompt">In&nbsp;[4]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython3"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="k">import</span> <span class="n">symbolic</span>
+<div class=" highlight hl-ipython2"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic</span>
 
 <span class="nd">@symbolic</span>
 <span class="k">class</span> <span class="nc">MultiplyBySomething</span><span class="p">:</span>
@@ -465,7 +453,7 @@ Note that since the value is attached to the instance, it persists if functons a
     
 <span class="n">f</span> <span class="o">=</span> <span class="n">MultiplyBySomething</span><span class="p">(</span><span class="mi">3</span><span class="p">)</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
 
-<span class="nb">print</span> <span class="s">&#39;3*4=%s&#39;</span> <span class="o">%</span> <span class="n">f</span><span class="p">(</span><span class="mi">4</span><span class="p">)</span>
+<span class="k">print</span> <span class="s">&#39;3*4=</span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="n">f</span><span class="p">(</span><span class="mi">4</span><span class="p">)</span>
 </pre></div>
 
 </div>
@@ -502,21 +490,21 @@ Note that since the value is attached to the instance, it persists if functons a
 <div class="prompt input_prompt">In&nbsp;[5]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython3"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="k">import</span> <span class="n">symbolic</span>
+<div class=" highlight hl-ipython2"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic</span>
 
 <span class="nd">@symbolic</span>
 <span class="k">def</span> <span class="nf">add_and_div</span><span class="p">(</span><span class="n">x</span><span class="p">,</span> <span class="n">y</span><span class="p">,</span> <span class="n">z</span><span class="p">):</span>
     <span class="k">return</span> <span class="p">(</span><span class="n">x</span><span class="o">+</span><span class="n">y</span><span class="p">)</span><span class="o">/</span><span class="n">z</span>
 
 <span class="n">f</span> <span class="o">=</span> <span class="n">add_and_div</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
-<span class="nb">print</span> <span class="s">&#39;(2+4)/3 = %s&#39;</span> <span class="o">%</span> <span class="n">f</span><span class="p">(</span><span class="n">x</span><span class="o">=</span><span class="mi">4</span><span class="p">,</span> <span class="n">y</span><span class="o">=</span><span class="mi">2</span><span class="p">,</span> <span class="n">z</span><span class="o">=</span><span class="mi">3</span><span class="p">)</span>
-<span class="nb">print</span> <span class="s">&#39;(1+3)/2 = %s&#39;</span> <span class="o">%</span> <span class="n">f</span><span class="p">(</span><span class="n">z</span><span class="o">=</span><span class="mi">2</span><span class="p">,</span> <span class="n">y</span><span class="o">=</span><span class="mi">3</span><span class="p">,</span> <span class="n">x</span><span class="o">=</span><span class="mi">1</span><span class="p">)</span>
+<span class="k">print</span> <span class="s">&#39;(2+4)/3 = </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="n">f</span><span class="p">(</span><span class="n">x</span><span class="o">=</span><span class="mi">4</span><span class="p">,</span> <span class="n">y</span><span class="o">=</span><span class="mi">2</span><span class="p">,</span> <span class="n">z</span><span class="o">=</span><span class="mi">3</span><span class="p">)</span>
+<span class="k">print</span> <span class="s">&#39;(1+3)/2 = </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="n">f</span><span class="p">(</span><span class="n">z</span><span class="o">=</span><span class="mi">2</span><span class="p">,</span> <span class="n">y</span><span class="o">=</span><span class="mi">3</span><span class="p">,</span> <span class="n">x</span><span class="o">=</span><span class="mi">1</span><span class="p">)</span>
 
 <span class="k">try</span><span class="p">:</span>
-    <span class="nb">print</span> <span class="s">&#39;Lets try again, but leave x as an unnamed arg...&#39;</span>
+    <span class="k">print</span> <span class="s">&#39;Lets try again, but leave x as an unnamed arg...&#39;</span>
     <span class="n">f</span><span class="p">(</span><span class="mi">2</span><span class="p">,</span> <span class="n">y</span><span class="o">=</span><span class="mi">4</span><span class="p">,</span> <span class="n">z</span><span class="o">=</span><span class="mf">3.</span><span class="p">)</span>
 <span class="k">except</span> <span class="ne">KeyError</span> <span class="k">as</span> <span class="n">e</span><span class="p">:</span>
-    <span class="nb">print</span> <span class="s">&#39;You were inconsistent - referenced x as a kwarg in the first call but not the second.&#39;</span>
+    <span class="k">print</span> <span class="s">&#39;You were inconsistent - referenced x as a kwarg in the first call but not the second.&#39;</span>
 </pre></div>
 
 </div>
@@ -550,28 +538,30 @@ You were inconsistent - referenced x as a kwarg in the first call but not the se
 <h3 id="6A:-Testing-Initial-Values">6A: Testing Initial Values<a class="anchor-link" href="#6A:-Testing-Initial-Values">&#182;</a></h3><p>Theano allows you to add "test-values" to your symbolic variables (<a href="http://deeplearning.net/software/theano/tutorial/debug_faq.html">see tutorial</a>).  This helps to catch shape-errors at compile-time instead of run-time, where it is difficult to find the line of code that caused them.  However, it can be a bit of extra work for the programmer, because they have to manually attach test values to their variables.  Fortunately, since Plato compiles your functions on the first pass, it can attach test-values "under the hood".</p>
 <p>For example, lets look at a matrix multiplication, where we accidently get the shapes of our matrices wrong.  Since all inputs are given test values, we can easily track down the error - the traceback will lead back to the correct line.  This would not have been possible without test values, because the error would occur in the compiled code, which is no-longer linked to the source code.</p>
 <p>Plato attaches the following properties to all symbolic variables:<br>
-<strong>var.ival</strong> - The initial value of the variable (a numpy array or scalar)<br>
-<strong>var.ishape</strong> - The initial shape of the variable<br>
-<strong>var.indim</strong> - The initial number of dimensions of the variable<br>
-<strong>var.idtype</strong> - The initial dtype of the variable</p>
+<strong><code>var.ival</code></strong> - The initial value of the variable (a numpy array or scalar)<br>
+<strong><code>var.ishape</code></strong> - The initial shape of the variable<br>
+<strong><code>var.indim</code></strong> - The initial number of dimensions of the variable<br>
+<strong><code>var.idtype</code></strong> - The initial dtype of the variable</p>
 
 </div>
 </div>
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[4]:</div>
+<div class="prompt input_prompt">In&nbsp;[7]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython3"><pre><span class="kn">import</span> <span class="nn">numpy</span> <span class="k">as</span> <span class="nn">np</span>
-<span class="kn">from</span> <span class="nn">plato.core</span> <span class="k">import</span> <span class="n">symbolic</span>
+<div class=" highlight hl-ipython2"><pre><span class="kn">import</span> <span class="nn">numpy</span> <span class="kn">as</span> <span class="nn">np</span>
+<span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic</span>
 
 <span class="nd">@symbolic</span>
 <span class="k">def</span> <span class="nf">forward_pass</span><span class="p">(</span><span class="n">x</span><span class="p">,</span> <span class="n">w</span><span class="p">):</span>
-    <span class="nb">print</span> <span class="s">&#39;x-shape: %s&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">x</span><span class="o">.</span><span class="n">ishape</span><span class="p">,</span> <span class="p">)</span>
-    <span class="nb">print</span> <span class="s">&#39;w-shape: %s&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">w</span><span class="o">.</span><span class="n">ishape</span><span class="p">,</span> <span class="p">)</span>
+    <span class="k">print</span> <span class="s">&#39;x-shape: </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">x</span><span class="o">.</span><span class="n">ishape</span><span class="p">,</span> <span class="p">)</span>
+    <span class="k">print</span> <span class="s">&#39;w-shape: </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">w</span><span class="o">.</span><span class="n">ishape</span><span class="p">,</span> <span class="p">)</span>
     <span class="c"># Note that the above test-values only display on the first iteration.</span>
-    <span class="k">return</span> <span class="n">x</span><span class="o">.</span><span class="n">dot</span><span class="p">(</span><span class="n">w</span><span class="p">)</span>
+    <span class="n">y</span> <span class="o">=</span> <span class="n">x</span><span class="o">.</span><span class="n">dot</span><span class="p">(</span><span class="n">w</span><span class="p">)</span>
+    <span class="k">print</span> <span class="s">&#39;Success! y-shape: </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">y</span><span class="o">.</span><span class="n">ishape</span><span class="p">,</span> <span class="p">)</span>
+    <span class="k">return</span> <span class="n">y</span>
 
 <span class="n">f</span> <span class="o">=</span> <span class="n">forward_pass</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
 
@@ -580,7 +570,11 @@ You were inconsistent - referenced x as a kwarg in the first call but not the se
     <span class="n">h</span> <span class="o">=</span> <span class="n">f</span><span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">random</span><span class="o">.</span><span class="n">randn</span><span class="p">(</span><span class="mi">5</span><span class="p">,</span> <span class="mi">4</span><span class="p">),</span> <span class="n">np</span><span class="o">.</span><span class="n">random</span><span class="o">.</span><span class="n">rand</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="mi">4</span><span class="p">))</span>  
 <span class="k">except</span> <span class="ne">ValueError</span> <span class="k">as</span> <span class="n">err</span><span class="p">:</span>
     <span class="c"># If you do not catch the error, you get a stacktrace which points to the line at fault.</span>
-    <span class="nb">print</span> <span class="s">&#39;%s: %s&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">err</span><span class="o">.</span><span class="n">__class__</span><span class="o">.</span><span class="n">__name__</span><span class="p">,</span> <span class="n">err</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
+    <span class="k">print</span> <span class="s">&#39;</span><span class="si">%s</span><span class="s">: </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">err</span><span class="o">.</span><span class="n">__class__</span><span class="o">.</span><span class="n">__name__</span><span class="p">,</span> <span class="n">err</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
+<span class="k">print</span> <span class="s">&quot;Now we try again with the correct shape, and it succeeds.&quot;</span>
+<span class="n">h</span> <span class="o">=</span> <span class="n">f</span><span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">random</span><span class="o">.</span><span class="n">randn</span><span class="p">(</span><span class="mi">5</span><span class="p">,</span> <span class="mi">4</span><span class="p">),</span> <span class="n">np</span><span class="o">.</span><span class="n">random</span><span class="o">.</span><span class="n">rand</span><span class="p">(</span><span class="mi">4</span><span class="p">,</span> <span class="mi">3</span><span class="p">))</span>  
+<span class="k">print</span> <span class="s">&quot;Note that if we run again we print nothing because the symbolic function is just run once, on the first pass.&quot;</span>
+<span class="n">h</span> <span class="o">=</span> <span class="n">f</span><span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">random</span><span class="o">.</span><span class="n">randn</span><span class="p">(</span><span class="mi">5</span><span class="p">,</span> <span class="mi">4</span><span class="p">),</span> <span class="n">np</span><span class="o">.</span><span class="n">random</span><span class="o">.</span><span class="n">rand</span><span class="p">(</span><span class="mi">4</span><span class="p">,</span> <span class="mi">3</span><span class="p">))</span>  
 </pre></div>
 
 </div>
@@ -596,6 +590,11 @@ You were inconsistent - referenced x as a kwarg in the first call but not the se
 <pre>x-shape: (5, 4)
 w-shape: (3, 4)
 ValueError: shapes (5,4) and (3,4) not aligned: 4 (dim 1) != 3 (dim 0)
+Now we try again with the correct shape, and it succeeds.
+x-shape: (5, 4)
+w-shape: (4, 3)
+Success! y-shape: (5, 3)
+Note that if we run again we print nothing because the symbolic function is just run once, on the first pass.
 </pre>
 </div>
 </div>
@@ -609,31 +608,31 @@ ValueError: shapes (5,4) and (3,4) not aligned: 4 (dim 1) != 3 (dim 0)
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<h3 id="6B:-Variable-Traces">6B: Variable Traces<a class="anchor-link" href="#6B:-Variable-Traces">&#182;</a></h3><p>It can also be useful to print/plot traces of intermediate values.  Ordinarily in theano, this would require setting those variables as outputs, and restructuring code to peek at what would normally be an internal variables.  Plato does a bit of magic which allows you to print/plot/do anything with internal variables.  The following example illustrates this:</p>
+<h3 id="6B:-Variable-Traces">6B: Variable Traces<a class="anchor-link" href="#6B:-Variable-Traces">&#182;</a></h3><p>We can use <strong><code>var.ival</code></strong> and its brothers to access variable values on the first pass, but what if we want to view variable values every time the function is called?  Ordinarily in Theano, this would require setting those variables as outputs, and restructuring code to peek at what would normally be an internal variables.  Plato does a bit of magic which allows you to print/plot/do anything with internal variables.  The following example illustrates this:</p>
 
 </div>
 </div>
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[3]:</div>
+<div class="prompt input_prompt">In&nbsp;[8]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython3"><pre><span class="kn">import</span> <span class="nn">numpy</span> <span class="k">as</span> <span class="nn">np</span>
-<span class="kn">from</span> <span class="nn">plato.core</span> <span class="k">import</span> <span class="n">symbolic</span><span class="p">,</span> <span class="n">tdbprint</span>
-<span class="kn">import</span> <span class="nn">theano.tensor</span> <span class="k">as</span> <span class="nn">tt</span>
-<span class="kn">import</span> <span class="nn">theano</span>
+<div class=" highlight hl-ipython2"><pre><span class="kn">import</span> <span class="nn">numpy</span> <span class="kn">as</span> <span class="nn">np</span>
+<span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic</span><span class="p">,</span> <span class="n">tdbprint</span><span class="p">,</span> <span class="n">create_shared_variable</span>
+<span class="kn">import</span> <span class="nn">theano.tensor</span> <span class="kn">as</span> <span class="nn">tt</span>
 
 <span class="k">class</span> <span class="nc">Layer</span><span class="p">:</span>
     
     <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">w</span><span class="p">):</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">w</span> <span class="o">=</span> <span class="n">theano</span><span class="o">.</span><span class="n">shared</span><span class="p">(</span><span class="n">w</span><span class="p">)</span>
+        <span class="bp">self</span><span class="o">.</span><span class="n">w</span> <span class="o">=</span> <span class="n">create_shared_variable</span><span class="p">(</span><span class="n">w</span><span class="p">)</span>
         
     <span class="nd">@symbolic</span>
     <span class="k">def</span> <span class="nf">forward_pass</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">x</span><span class="p">):</span>
         <span class="n">pre_sigmoid</span> <span class="o">=</span> <span class="n">x</span><span class="o">.</span><span class="n">dot</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">w</span><span class="p">)</span>
         <span class="n">tdbprint</span><span class="p">(</span><span class="n">pre_sigmoid</span><span class="p">,</span> <span class="n">name</span> <span class="o">=</span> <span class="s">&#39;Pre-Sigmoid Activation&#39;</span><span class="p">)</span>  <span class="c"># Here we make a trace of an internal variable</span>
         <span class="n">y</span> <span class="o">=</span> <span class="n">tt</span><span class="o">.</span><span class="n">nnet</span><span class="o">.</span><span class="n">sigmoid</span><span class="p">(</span><span class="n">pre_sigmoid</span><span class="p">)</span>
+        <span class="n">tdbprint</span><span class="p">(</span><span class="n">y</span><span class="p">,</span> <span class="n">name</span> <span class="o">=</span> <span class="s">&#39;Post-Sigmoid Activation&#39;</span><span class="p">)</span>  <span class="c"># Here we make a trace of an internal variable</span>
         <span class="k">return</span> <span class="n">y</span>
     
 <span class="n">n_samples</span> <span class="o">=</span> <span class="mi">1</span>
@@ -642,9 +641,8 @@ ValueError: shapes (5,4) and (3,4) not aligned: 4 (dim 1) != 3 (dim 0)
     
 <span class="n">layer</span> <span class="o">=</span> <span class="n">Layer</span><span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">random</span><span class="o">.</span><span class="n">randn</span><span class="p">(</span><span class="n">n_in</span><span class="p">,</span> <span class="n">n_out</span><span class="p">))</span>
 <span class="n">fwd_fcn</span> <span class="o">=</span> <span class="n">layer</span><span class="o">.</span><span class="n">forward_pass</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
-<span class="k">for</span> <span class="n">_</span> <span class="ow">in</span> <span class="n">xrange</span><span class="p">(</span><span class="mi">3</span><span class="p">):</span>
+<span class="k">for</span> <span class="n">_</span> <span class="ow">in</span> <span class="nb">xrange</span><span class="p">(</span><span class="mi">3</span><span class="p">):</span>
     <span class="n">y</span> <span class="o">=</span> <span class="n">fwd_fcn</span><span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">random</span><span class="o">.</span><span class="n">randn</span><span class="p">(</span><span class="n">n_samples</span><span class="p">,</span> <span class="n">n_in</span><span class="p">))</span>
-    <span class="nb">print</span> <span class="s">&#39;Post Sigmoid Activation: %s&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">y</span><span class="p">)</span>
 </pre></div>
 
 </div>
@@ -657,12 +655,12 @@ ValueError: shapes (5,4) and (3,4) not aligned: 4 (dim 1) != 3 (dim 0)
 
 <div class="output_area"><div class="prompt"></div>
 <div class="output_subarea output_stream output_stdout output_text">
-<pre>Pre-Sigmoid Activation: [[ 4.40823978 -3.22244603  2.0160825 ]]
-Post Sigmoid Activation: [[ 0.98796989  0.03832972  0.88247532]]
-Pre-Sigmoid Activation: [[-0.84914375  1.78727461  1.03616111]]
-Post Sigmoid Activation: [[ 0.29961251  0.85659281  0.73810861]]
-Pre-Sigmoid Activation: [[-0.31623953  1.34197376  1.74131986]]
-Post Sigmoid Activation: [[ 0.42159248  0.79281434  0.85085463]]
+<pre>Pre-Sigmoid Activation: [[-0.47407049 -4.29749966 -0.30280173]]
+Post-Sigmoid Activation: [[ 0.38365325  0.01341998  0.42487273]]
+Pre-Sigmoid Activation: [[ 1.62998915  3.40799332 -0.39556655]]
+Post-Sigmoid Activation: [[ 0.83616817  0.96795344  0.40237799]]
+Pre-Sigmoid Activation: [[ 0.15886441 -0.46783638 -0.82146084]]
+Post-Sigmoid Activation: [[ 0.5396328   0.38512847  0.30545366]]
 </pre>
 </div>
 </div>
@@ -676,7 +674,8 @@ Post Sigmoid Activation: [[ 0.42159248  0.79281434  0.85085463]]
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p>You can also plot internal variables using the function <code>tdbplot</code> in <code>plato.tools.tdb_plotting</code>, but this tutorial does not cover it.</p>
+<p>If you want to store and retrieve internal variable values, you can use <strong><code>tdb_trace</code></strong>, and <strong><code>get_tdb_traces</code></strong> in <code>plato.core</code>.</p>
+<p>You can also create live plots of internal variables using the function <strong><code>tdbplot</code></strong> in <code>plato.tools.tdb_plotting</code>, but this tutorial does not cover it.</p>
 
 </div>
 </div>
@@ -686,7 +685,7 @@ Post Sigmoid Activation: [[ 0.42159248  0.79281434  0.85085463]]
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<h2 id="7.-Enforcing-Interfaces">7. Enforcing Interfaces<a class="anchor-link" href="#7.-Enforcing-Interfaces">&#182;</a></h2><p>In larger programs, it can be useful to enforce interfaces - that is, functions are required to obey a certain contract.  This allows function A to use function B without knowing in particular which function it is.  For instance, you may have some code that iterates through a dataset and trains a predictor, but doesn't necessarily know what kind of predictor it is - just that it has a <em>train</em> function that accepts inputs and targets, and returns updates.</p>
+<h2 id="7.-Enforcing-Interfaces">7. Enforcing Interfaces<a class="anchor-link" href="#7.-Enforcing-Interfaces">&#182;</a></h2><p>In larger programs, it can be useful to enforce interfaces - that is, functions are required to obey a certain contract.  This allows function A to use function B without knowing in particular which function it is.  For instance, you may have some code that iterates through a dataset and trains a predictor, but doesn't necessarily know what kind of predictor it is - just that it has a <em>train</em> function that accepts inputs and targets, updates some internal state variable.</p>
 <p>For this reason, we have an extended set of decorators which enforce type-checking on inputs, outputs, and updates.</p>
 <p><strong><code>@symbolic</code></strong> - No format requirements.<br>
 <strong><code>@symbolic_simple</code></strong> - Returns a single output variable.<br>
@@ -702,38 +701,37 @@ Post Sigmoid Activation: [[ 0.42159248  0.79281434  0.85085463]]
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[2]:</div>
+<div class="prompt input_prompt">In&nbsp;[1]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython3"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="k">import</span> <span class="n">symbolic_stateless</span><span class="p">,</span> <span class="n">symbolic</span><span class="p">,</span> <span class="n">SymbolicFormatError</span><span class="p">,</span> <span class="n">add_update</span>
-<span class="kn">import</span> <span class="nn">theano</span>
+<div class=" highlight hl-ipython2"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic_stateless</span><span class="p">,</span> <span class="n">symbolic</span><span class="p">,</span> <span class="n">SymbolicFormatError</span><span class="p">,</span> <span class="n">add_update</span><span class="p">,</span> <span class="n">create_shared_variable</span>
 
 <span class="nd">@symbolic_stateless</span> <span class="c"># Bad! We decorated with &quot;symbolic_stateless&quot;, but we make a state update inside</span>
 <span class="k">def</span> <span class="nf">running_sum</span><span class="p">(</span><span class="n">x</span><span class="p">):</span>
-    <span class="n">shared_var</span> <span class="o">=</span> <span class="n">theano</span><span class="o">.</span><span class="n">shared</span><span class="p">(</span><span class="mi">0</span><span class="p">)</span>
+    <span class="n">shared_var</span> <span class="o">=</span> <span class="n">create_shared_variable</span><span class="p">(</span><span class="mi">0</span><span class="p">)</span>
     <span class="n">y</span> <span class="o">=</span> <span class="n">x</span> <span class="o">+</span> <span class="n">shared_var</span>
     <span class="n">add_update</span><span class="p">(</span><span class="n">shared_var</span><span class="p">,</span> <span class="n">y</span><span class="p">)</span> 
     <span class="k">return</span> <span class="n">y</span> 
 
 <span class="n">f</span> <span class="o">=</span> <span class="n">running_sum</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
-<span class="nb">print</span> <span class="s">&#39;Trying to run incorrectly-decorated function...&#39;</span>
+<span class="k">print</span> <span class="s">&#39;Trying to run incorrectly-decorated function...&#39;</span>
 <span class="k">try</span><span class="p">:</span> 
     <span class="n">f</span><span class="p">(</span><span class="mi">3</span><span class="p">)</span>
 <span class="k">except</span> <span class="n">SymbolicFormatError</span> <span class="k">as</span> <span class="n">err</span><span class="p">:</span>
-    <span class="nb">print</span> <span class="s">&#39;  %s: %s&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">err</span><span class="o">.</span><span class="n">__class__</span><span class="o">.</span><span class="n">__name__</span><span class="p">,</span> <span class="n">err</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
+    <span class="k">print</span> <span class="s">&#39;  </span><span class="si">%s</span><span class="s">: </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">err</span><span class="o">.</span><span class="n">__class__</span><span class="o">.</span><span class="n">__name__</span><span class="p">,</span> <span class="n">err</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
 
-<span class="nb">print</span> <span class="s">&#39;Lets try again with the correct format....&#39;</span>
+<span class="k">print</span> <span class="s">&#39;Lets try again with the correct format....&#39;</span>
 
 <span class="nd">@symbolic</span>
 <span class="k">def</span> <span class="nf">running_sum</span><span class="p">(</span><span class="n">x</span><span class="p">):</span>
-    <span class="n">shared_var</span> <span class="o">=</span> <span class="n">theano</span><span class="o">.</span><span class="n">shared</span><span class="p">(</span><span class="mi">0</span><span class="p">)</span>
+    <span class="n">shared_var</span> <span class="o">=</span> <span class="n">create_shared_variable</span><span class="p">(</span><span class="mi">0</span><span class="p">)</span>
     <span class="n">y</span> <span class="o">=</span> <span class="n">x</span> <span class="o">+</span> <span class="n">shared_var</span>
     <span class="n">add_update</span><span class="p">(</span><span class="n">shared_var</span><span class="p">,</span> <span class="n">y</span><span class="p">)</span> 
     <span class="k">return</span> <span class="n">y</span> 
 
 <span class="n">f</span> <span class="o">=</span> <span class="n">running_sum</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
 
-<span class="nb">print</span> <span class="s">&#39;  cumsum([1,2,3,4]) = %s&#39;</span> <span class="o">%</span> <span class="p">([</span><span class="nb">int</span><span class="p">(</span><span class="n">f</span><span class="p">(</span><span class="n">i</span><span class="p">))</span> <span class="k">for</span> <span class="n">i</span> <span class="ow">in</span> <span class="n">xrange</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="mi">5</span><span class="p">)],</span> <span class="p">)</span>
+<span class="k">print</span> <span class="s">&#39;  cumsum([1,2,3,4]) = </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">([</span><span class="nb">int</span><span class="p">(</span><span class="n">f</span><span class="p">(</span><span class="n">i</span><span class="p">))</span> <span class="k">for</span> <span class="n">i</span> <span class="ow">in</span> <span class="nb">xrange</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="mi">5</span><span class="p">)],</span> <span class="p">)</span>
 </pre></div>
 
 </div>
@@ -747,7 +745,7 @@ Post Sigmoid Activation: [[ 0.42159248  0.79281434  0.85085463]]
 <div class="output_area"><div class="prompt"></div>
 <div class="output_subarea output_stream output_stdout output_text">
 <pre>Trying to run incorrectly-decorated function...
-  SymbolicFormatError: Function &lt;function running_sum at 0x107169ed8&gt; should have created no state updates, but it created updates: [(&lt;TensorType(int64, scalar)&gt;, Elemwise{add,no_inplace}.0)]
+  SymbolicFormatError: Function &lt;function running_sum at 0x104da58c0&gt; should have created no state updates, but it created updates: [(&lt;TensorType(int64, scalar)&gt;, Elemwise{add,no_inplace}.0)]
 Lets try again with the correct format....
   cumsum([1,2,3,4]) = [1, 3, 6, 10]
 </pre>
@@ -770,10 +768,10 @@ Lets try again with the correct format....
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[1]:</div>
+<div class="prompt input_prompt">In&nbsp;[13]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython3"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="k">import</span> <span class="n">symbolic</span>
+<div class=" highlight hl-ipython2"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic</span>
 
 <span class="nd">@symbolic</span>
 <span class="k">def</span> <span class="nf">multiply</span><span class="p">(</span><span class="n">x</span><span class="p">,</span> <span class="n">y</span><span class="p">):</span>
@@ -781,8 +779,8 @@ Lets try again with the correct format....
 
 <span class="n">f_mult_by_3</span> <span class="o">=</span> <span class="n">multiply</span><span class="o">.</span><span class="n">compile</span><span class="p">(</span><span class="n">fixed_args</span> <span class="o">=</span> <span class="nb">dict</span><span class="p">(</span><span class="n">x</span><span class="o">=</span><span class="mi">3</span><span class="p">))</span>
 
-<span class="nb">print</span> <span class="s">&#39;3*2 = %s&#39;</span> <span class="o">%</span> <span class="n">f_mult_by_3</span><span class="p">(</span><span class="n">y</span><span class="o">=</span><span class="mi">2</span><span class="p">)</span>
-<span class="nb">print</span> <span class="s">&#39;3*5 = %s&#39;</span> <span class="o">%</span> <span class="n">f_mult_by_3</span><span class="p">(</span><span class="n">y</span><span class="o">=</span><span class="mi">5</span><span class="p">)</span>
+<span class="k">print</span> <span class="s">&#39;3*2 = </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="n">f_mult_by_3</span><span class="p">(</span><span class="n">y</span><span class="o">=</span><span class="mi">2</span><span class="p">)</span>
+<span class="k">print</span> <span class="s">&#39;3*5 = </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="n">f_mult_by_3</span><span class="p">(</span><span class="n">y</span><span class="o">=</span><span class="mi">5</span><span class="p">)</span>
 </pre></div>
 
 </div>
@@ -810,23 +808,66 @@ Lets try again with the correct format....
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<h2 id="9.-Done.">9. Done.<a class="anchor-link" href="#9.-Done.">&#182;</a></h2><p>Congratulations, you made it through the Plato tutorial.</p>
+<h2 id="9.-Looping-with-scan">9. Looping with scan<a class="anchor-link" href="#9.-Looping-with-scan">&#182;</a></h2><p>For looping operations in Theano, there is the <strong><code>scan</code></strong> function.  In Plato, symbolic functions have a <strong><code>.scan</code></strong> method of their own that you can call to output the result of the given function when called in a loop with updates applied sequentially and the return values piled into an array.  The arguments have all the same names and semantics as Theano's scan function, so see Theano's <a href="http://deeplearning.net/software/theano/library/scan.html">scan documentation</a> for details.</p>
 
 </div>
 </div>
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[&nbsp;]:</div>
+<div class="prompt input_prompt">In&nbsp;[6]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython3"><pre> 
+<div class=" highlight hl-ipython2"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic</span><span class="p">,</span> <span class="n">create_shared_variable</span><span class="p">,</span> <span class="n">add_update</span>
+<span class="kn">import</span> <span class="nn">numpy</span> <span class="kn">as</span> <span class="nn">np</span>
+
+<span class="nd">@symbolic</span>
+<span class="k">def</span> <span class="nf">running_sum</span><span class="p">(</span><span class="n">x</span><span class="p">):</span>
+    <span class="n">shared_var</span> <span class="o">=</span> <span class="n">create_shared_variable</span><span class="p">(</span><span class="mi">0</span><span class="p">)</span>
+    <span class="n">y</span> <span class="o">=</span> <span class="n">x</span> <span class="o">+</span> <span class="n">shared_var</span>
+    <span class="n">add_update</span><span class="p">(</span><span class="n">shared_var</span><span class="p">,</span> <span class="n">y</span><span class="p">)</span> 
+    <span class="k">return</span> <span class="n">y</span> 
+
+<span class="nd">@symbolic</span>
+<span class="k">def</span> <span class="nf">running_cumsum</span><span class="p">(</span><span class="n">arr</span><span class="p">):</span>
+    <span class="n">cumsum</span> <span class="o">=</span> <span class="n">running_sum</span><span class="o">.</span><span class="n">scan</span><span class="p">(</span><span class="n">sequences</span> <span class="o">=</span> <span class="p">[</span><span class="n">arr</span><span class="p">])</span>
+    <span class="k">return</span> <span class="n">cumsum</span>
+
+<span class="n">f</span> <span class="o">=</span> <span class="n">running_cumsum</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
+
+<span class="k">print</span> <span class="s">&#39;Running Cumsum of [1,2,3,4]: </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">f</span><span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">arange</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="mi">5</span><span class="p">)),</span> <span class="p">)</span>
+<span class="k">print</span> <span class="s">&#39;Continuing Running Cumsum of [1,2,3,4]: </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">f</span><span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">arange</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="mi">5</span><span class="p">)),</span> <span class="p">)</span>
 </pre></div>
 
 </div>
 </div>
 </div>
 
+<div class="output_wrapper">
+<div class="output">
+
+
+<div class="output_area"><div class="prompt"></div>
+<div class="output_subarea output_stream output_stdout output_text">
+<pre>Running Cumsum of [1,2,3,4]: [ 1  3  6 10]
+Continuing Running Cumsum of [1,2,3,4]: [11 13 16 20]
+</pre>
+</div>
+</div>
+
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing text_cell rendered">
+<div class="prompt input_prompt">
+</div>
+<div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<h2 id="10.-Done">10. Done<a class="anchor-link" href="#10.-Done">&#182;</a></h2><p>Congratulations.  You've made it through the Plato tutorial.  You may now want to see examples of various <a href="https://github.com/petered/plato/wiki/Algorithms-in-Plato">Learning Algorithms in Plato</a>.</p>
+
+</div>
+</div>
 </div>
     </div>
   </div>

--- a/plato_tutorial.html
+++ b/plato_tutorial.html
@@ -200,14 +200,14 @@ div#notebook {
 <div class="prompt input_prompt">In&nbsp;[3]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic</span>
+<div class=" highlight hl-ipython3"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="k">import</span> <span class="n">symbolic</span>
 
 <span class="nd">@symbolic</span>
 <span class="k">def</span> <span class="nf">add_two_numbers</span><span class="p">(</span><span class="n">x</span><span class="p">,</span> <span class="n">y</span><span class="p">):</span>
     <span class="k">return</span> <span class="n">x</span><span class="o">+</span><span class="n">y</span>
 
 <span class="n">f</span> <span class="o">=</span> <span class="n">add_two_numbers</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
-<span class="k">print</span> <span class="s">&#39;3+4=</span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="n">f</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="mi">4</span><span class="p">)</span>
+<span class="nb">print</span> <span class="s">&#39;3+4=%s&#39;</span> <span class="o">%</span> <span class="n">f</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="mi">4</span><span class="p">)</span>
 </pre></div>
 
 </div>
@@ -241,18 +241,18 @@ div#notebook {
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[2]:</div>
+<div class="prompt input_prompt">In&nbsp;[9]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span class="kn">import</span> <span class="nn">theano</span>
-<span class="kn">from</span> <span class="nn">theano.tensor</span> <span class="kn">import</span> <span class="n">scalar</span>
+<div class=" highlight hl-ipython3"><pre><span class="kn">import</span> <span class="nn">theano</span>
+<span class="kn">from</span> <span class="nn">theano.tensor</span> <span class="k">import</span> <span class="n">scalar</span>
 
 <span class="n">x</span> <span class="o">=</span> <span class="n">scalar</span><span class="p">(</span><span class="n">dtype</span> <span class="o">=</span> <span class="s">&#39;int32&#39;</span><span class="p">)</span>
 <span class="n">y</span> <span class="o">=</span> <span class="n">scalar</span><span class="p">(</span><span class="n">dtype</span> <span class="o">=</span> <span class="s">&#39;int32&#39;</span><span class="p">)</span>
 <span class="n">z</span> <span class="o">=</span> <span class="n">x</span><span class="o">+</span><span class="n">y</span>
 
 <span class="n">f</span> <span class="o">=</span> <span class="n">theano</span><span class="o">.</span><span class="n">function</span><span class="p">(</span><span class="n">inputs</span> <span class="o">=</span> <span class="p">[</span><span class="n">x</span><span class="p">,</span> <span class="n">y</span><span class="p">],</span> <span class="n">outputs</span> <span class="o">=</span> <span class="n">z</span><span class="p">)</span>
-<span class="k">print</span> <span class="s">&#39;3+4=</span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="n">f</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="mi">4</span><span class="p">)</span>
+<span class="nb">print</span> <span class="s">&#39;3+4=%s&#39;</span> <span class="o">%</span> <span class="n">f</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="mi">4</span><span class="p">)</span>
 </pre></div>
 
 </div>
@@ -266,6 +266,16 @@ div#notebook {
 <div class="output_area"><div class="prompt"></div>
 <div class="output_subarea output_stream output_stdout output_text">
 <pre>3+4=7
+</pre>
+</div>
+</div>
+
+<div class="output_area"><div class="prompt"></div>
+<div class="output_subarea output_stream output_stderr output_text">
+<pre>/Users/peter/projects/argmaxlab/venv/src/theano/theano/tensor/var.py:128: UserWarning: Warning, Cannot compute test value: input 0 (&lt;TensorType(int32, scalar)&gt;) of Op Elemwise{add,no_inplace}(&lt;TensorType(int32, scalar)&gt;, &lt;TensorType(int32, scalar)&gt;) missing default value
+  return theano.tensor.basic.add(self, other)
+/Users/peter/projects/argmaxlab/venv/src/theano/theano/tensor/var.py:128: UserWarning: Warning, Cannot compute test value: input 1 (&lt;TensorType(int32, scalar)&gt;) of Op Elemwise{add,no_inplace}(&lt;TensorType(int32, scalar)&gt;, &lt;TensorType(int32, scalar)&gt;) missing default value
+  return theano.tensor.basic.add(self, other)
 </pre>
 </div>
 </div>
@@ -296,11 +306,11 @@ div#notebook {
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[14]:</div>
+<div class="prompt input_prompt">In&nbsp;[8]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span class="kn">import</span> <span class="nn">theano</span>
-<span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic</span><span class="p">,</span> <span class="n">add_update</span>
+<div class=" highlight hl-ipython3"><pre><span class="kn">import</span> <span class="nn">theano</span>
+<span class="kn">from</span> <span class="nn">plato.core</span> <span class="k">import</span> <span class="n">symbolic</span><span class="p">,</span> <span class="n">add_update</span>
 
 <span class="nd">@symbolic</span>
 <span class="k">def</span> <span class="nf">counter</span><span class="p">():</span>
@@ -310,10 +320,10 @@ div#notebook {
     <span class="k">return</span> <span class="n">new_count</span>
 
 <span class="n">f</span> <span class="o">=</span> <span class="n">counter</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
-<span class="k">print</span> <span class="s">&#39;I can count to ten.  See: </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">([</span><span class="nb">int</span><span class="p">(</span><span class="n">f</span><span class="p">())</span> <span class="k">for</span> <span class="n">_</span> <span class="ow">in</span> <span class="nb">xrange</span><span class="p">(</span><span class="mi">10</span><span class="p">)])</span>
+<span class="nb">print</span> <span class="s">&#39;I can count to ten.  See: %s&#39;</span> <span class="o">%</span> <span class="p">([</span><span class="nb">int</span><span class="p">(</span><span class="n">f</span><span class="p">())</span> <span class="k">for</span> <span class="n">_</span> <span class="ow">in</span> <span class="n">xrange</span><span class="p">(</span><span class="mi">10</span><span class="p">)])</span>
 
 <span class="n">f2</span> <span class="o">=</span> <span class="n">counter</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
-<span class="k">print</span> <span class="s">&#39;I can too: </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">([</span><span class="nb">int</span><span class="p">(</span><span class="n">f2</span><span class="p">())</span> <span class="k">for</span> <span class="n">_</span> <span class="ow">in</span> <span class="nb">xrange</span><span class="p">(</span><span class="mi">10</span><span class="p">)])</span>
+<span class="nb">print</span> <span class="s">&#39;I can too: %s&#39;</span> <span class="o">%</span> <span class="p">([</span><span class="nb">int</span><span class="p">(</span><span class="n">f2</span><span class="p">())</span> <span class="k">for</span> <span class="n">_</span> <span class="ow">in</span> <span class="n">xrange</span><span class="p">(</span><span class="mi">10</span><span class="p">)])</span>
 <span class="c"># Note that we start from scratch when we compile the function a new time, </span>
 <span class="c"># because the shared variable is initialized within the function call.  If we</span>
 <span class="c"># had declaired counter outside the function, the second count would run from </span>
@@ -352,10 +362,10 @@ I can too: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[17]:</div>
+<div class="prompt input_prompt">In&nbsp;[7]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic</span><span class="p">,</span> <span class="n">add_update</span>
+<div class=" highlight hl-ipython3"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="k">import</span> <span class="n">symbolic</span><span class="p">,</span> <span class="n">add_update</span>
 <span class="kn">import</span> <span class="nn">theano</span>
 
 <span class="k">class</span> <span class="nc">Collatz</span><span class="p">:</span>
@@ -380,18 +390,18 @@ I can too: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 <span class="n">mul_fcn</span> <span class="o">=</span> <span class="n">c</span><span class="o">.</span><span class="n">multiply_by_3_and_add_one</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
 
 <span class="n">value</span> <span class="o">=</span> <span class="n">c</span><span class="o">.</span><span class="n">value</span><span class="o">.</span><span class="n">get_value</span><span class="p">()</span>
-<span class="k">print</span> <span class="s">&#39;Demonstrate Collatz conjecture for initial value of </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="n">c</span><span class="o">.</span><span class="n">value</span><span class="o">.</span><span class="n">get_value</span><span class="p">()</span>
+<span class="nb">print</span> <span class="s">&#39;Demonstrate Collatz conjecture for initial value of %s&#39;</span> <span class="o">%</span> <span class="n">c</span><span class="o">.</span><span class="n">value</span><span class="o">.</span><span class="n">get_value</span><span class="p">()</span>
 
 <span class="k">while</span> <span class="n">value</span> <span class="o">!=</span> <span class="mi">1</span><span class="p">:</span>
     <span class="n">value</span> <span class="o">=</span> <span class="n">div_fcn</span><span class="p">()</span> <span class="k">if</span> <span class="n">value</span> <span class="o">%</span> <span class="mi">2</span> <span class="o">==</span> <span class="mi">0</span> <span class="k">else</span> <span class="n">mul_fcn</span><span class="p">()</span>
-    <span class="k">print</span> <span class="n">value</span>
+    <span class="nb">print</span> <span class="n">value</span>
 
-<span class="k">print</span> <span class="s">&#39;Note that since the value is attached to the instance, it persists if functons are recompiled.&#39;</span>
+<span class="nb">print</span> <span class="s">&#39;Note that since the value is attached to the instance, it persists if functons are recompiled.&#39;</span>
 <span class="n">new_div_fcn</span> <span class="o">=</span> <span class="n">c</span><span class="o">.</span><span class="n">divide_by_2</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
 <span class="n">new_mul_fcn</span> <span class="o">=</span> <span class="n">c</span><span class="o">.</span><span class="n">multiply_by_3_and_add_one</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
-<span class="k">for</span> <span class="n">_</span> <span class="ow">in</span> <span class="nb">xrange</span><span class="p">(</span><span class="mi">6</span><span class="p">):</span>
+<span class="k">for</span> <span class="n">_</span> <span class="ow">in</span> <span class="n">xrange</span><span class="p">(</span><span class="mi">6</span><span class="p">):</span>
     <span class="n">value</span> <span class="o">=</span> <span class="n">new_div_fcn</span><span class="p">()</span> <span class="k">if</span> <span class="n">value</span> <span class="o">%</span> <span class="mi">2</span> <span class="o">==</span> <span class="mi">0</span> <span class="k">else</span> <span class="n">new_mul_fcn</span><span class="p">()</span>
-    <span class="k">print</span> <span class="n">value</span>
+    <span class="nb">print</span> <span class="n">value</span>
 </pre></div>
 
 </div>
@@ -439,10 +449,10 @@ Note that since the value is attached to the instance, it persists if functons a
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[18]:</div>
+<div class="prompt input_prompt">In&nbsp;[6]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic</span>
+<div class=" highlight hl-ipython3"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="k">import</span> <span class="n">symbolic</span>
 
 <span class="nd">@symbolic</span>
 <span class="k">class</span> <span class="nc">MultiplyBySomething</span><span class="p">:</span>
@@ -455,7 +465,7 @@ Note that since the value is attached to the instance, it persists if functons a
     
 <span class="n">f</span> <span class="o">=</span> <span class="n">MultiplyBySomething</span><span class="p">(</span><span class="mi">3</span><span class="p">)</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
 
-<span class="k">print</span> <span class="s">&#39;3*4=</span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="n">f</span><span class="p">(</span><span class="mi">4</span><span class="p">)</span>
+<span class="nb">print</span> <span class="s">&#39;3*4=%s&#39;</span> <span class="o">%</span> <span class="n">f</span><span class="p">(</span><span class="mi">4</span><span class="p">)</span>
 </pre></div>
 
 </div>
@@ -489,24 +499,24 @@ Note that since the value is attached to the instance, it persists if functons a
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[19]:</div>
+<div class="prompt input_prompt">In&nbsp;[5]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic</span>
+<div class=" highlight hl-ipython3"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="k">import</span> <span class="n">symbolic</span>
 
 <span class="nd">@symbolic</span>
 <span class="k">def</span> <span class="nf">add_and_div</span><span class="p">(</span><span class="n">x</span><span class="p">,</span> <span class="n">y</span><span class="p">,</span> <span class="n">z</span><span class="p">):</span>
     <span class="k">return</span> <span class="p">(</span><span class="n">x</span><span class="o">+</span><span class="n">y</span><span class="p">)</span><span class="o">/</span><span class="n">z</span>
 
 <span class="n">f</span> <span class="o">=</span> <span class="n">add_and_div</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
-<span class="k">print</span> <span class="s">&#39;(2+4)/3 = </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="n">f</span><span class="p">(</span><span class="n">x</span><span class="o">=</span><span class="mi">4</span><span class="p">,</span> <span class="n">y</span><span class="o">=</span><span class="mi">2</span><span class="p">,</span> <span class="n">z</span><span class="o">=</span><span class="mi">3</span><span class="p">)</span>
-<span class="k">print</span> <span class="s">&#39;(1+3)/2 = </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="n">f</span><span class="p">(</span><span class="n">z</span><span class="o">=</span><span class="mi">2</span><span class="p">,</span> <span class="n">y</span><span class="o">=</span><span class="mi">3</span><span class="p">,</span> <span class="n">x</span><span class="o">=</span><span class="mi">1</span><span class="p">)</span>
+<span class="nb">print</span> <span class="s">&#39;(2+4)/3 = %s&#39;</span> <span class="o">%</span> <span class="n">f</span><span class="p">(</span><span class="n">x</span><span class="o">=</span><span class="mi">4</span><span class="p">,</span> <span class="n">y</span><span class="o">=</span><span class="mi">2</span><span class="p">,</span> <span class="n">z</span><span class="o">=</span><span class="mi">3</span><span class="p">)</span>
+<span class="nb">print</span> <span class="s">&#39;(1+3)/2 = %s&#39;</span> <span class="o">%</span> <span class="n">f</span><span class="p">(</span><span class="n">z</span><span class="o">=</span><span class="mi">2</span><span class="p">,</span> <span class="n">y</span><span class="o">=</span><span class="mi">3</span><span class="p">,</span> <span class="n">x</span><span class="o">=</span><span class="mi">1</span><span class="p">)</span>
 
 <span class="k">try</span><span class="p">:</span>
-    <span class="k">print</span> <span class="s">&#39;Lets try again, but leave x as an unnamed arg...&#39;</span>
+    <span class="nb">print</span> <span class="s">&#39;Lets try again, but leave x as an unnamed arg...&#39;</span>
     <span class="n">f</span><span class="p">(</span><span class="mi">2</span><span class="p">,</span> <span class="n">y</span><span class="o">=</span><span class="mi">4</span><span class="p">,</span> <span class="n">z</span><span class="o">=</span><span class="mf">3.</span><span class="p">)</span>
 <span class="k">except</span> <span class="ne">KeyError</span> <span class="k">as</span> <span class="n">e</span><span class="p">:</span>
-    <span class="k">print</span> <span class="s">&#39;You were inconsistent - referenced x as a kwarg in the first call but not the second.&#39;</span>
+    <span class="nb">print</span> <span class="s">&#39;You were inconsistent - referenced x as a kwarg in the first call but not the second.&#39;</span>
 </pre></div>
 
 </div>
@@ -550,16 +560,16 @@ You were inconsistent - referenced x as a kwarg in the first call but not the se
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[20]:</div>
+<div class="prompt input_prompt">In&nbsp;[4]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span class="kn">import</span> <span class="nn">numpy</span> <span class="kn">as</span> <span class="nn">np</span>
-<span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic</span>
+<div class=" highlight hl-ipython3"><pre><span class="kn">import</span> <span class="nn">numpy</span> <span class="k">as</span> <span class="nn">np</span>
+<span class="kn">from</span> <span class="nn">plato.core</span> <span class="k">import</span> <span class="n">symbolic</span>
 
 <span class="nd">@symbolic</span>
 <span class="k">def</span> <span class="nf">forward_pass</span><span class="p">(</span><span class="n">x</span><span class="p">,</span> <span class="n">w</span><span class="p">):</span>
-    <span class="k">print</span> <span class="s">&#39;x-shape: </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">x</span><span class="o">.</span><span class="n">ishape</span><span class="p">,</span> <span class="p">)</span>
-    <span class="k">print</span> <span class="s">&#39;w-shape: </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">w</span><span class="o">.</span><span class="n">ishape</span><span class="p">,</span> <span class="p">)</span>
+    <span class="nb">print</span> <span class="s">&#39;x-shape: %s&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">x</span><span class="o">.</span><span class="n">ishape</span><span class="p">,</span> <span class="p">)</span>
+    <span class="nb">print</span> <span class="s">&#39;w-shape: %s&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">w</span><span class="o">.</span><span class="n">ishape</span><span class="p">,</span> <span class="p">)</span>
     <span class="c"># Note that the above test-values only display on the first iteration.</span>
     <span class="k">return</span> <span class="n">x</span><span class="o">.</span><span class="n">dot</span><span class="p">(</span><span class="n">w</span><span class="p">)</span>
 
@@ -570,7 +580,7 @@ You were inconsistent - referenced x as a kwarg in the first call but not the se
     <span class="n">h</span> <span class="o">=</span> <span class="n">f</span><span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">random</span><span class="o">.</span><span class="n">randn</span><span class="p">(</span><span class="mi">5</span><span class="p">,</span> <span class="mi">4</span><span class="p">),</span> <span class="n">np</span><span class="o">.</span><span class="n">random</span><span class="o">.</span><span class="n">rand</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="mi">4</span><span class="p">))</span>  
 <span class="k">except</span> <span class="ne">ValueError</span> <span class="k">as</span> <span class="n">err</span><span class="p">:</span>
     <span class="c"># If you do not catch the error, you get a stacktrace which points to the line at fault.</span>
-    <span class="k">print</span> <span class="s">&#39;</span><span class="si">%s</span><span class="s">: </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">err</span><span class="o">.</span><span class="n">__class__</span><span class="o">.</span><span class="n">__name__</span><span class="p">,</span> <span class="n">err</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
+    <span class="nb">print</span> <span class="s">&#39;%s: %s&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">err</span><span class="o">.</span><span class="n">__class__</span><span class="o">.</span><span class="n">__name__</span><span class="p">,</span> <span class="n">err</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
 </pre></div>
 
 </div>
@@ -606,12 +616,12 @@ ValueError: shapes (5,4) and (3,4) not aligned: 4 (dim 1) != 3 (dim 0)
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[21]:</div>
+<div class="prompt input_prompt">In&nbsp;[3]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span class="kn">import</span> <span class="nn">numpy</span> <span class="kn">as</span> <span class="nn">np</span>
-<span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic</span><span class="p">,</span> <span class="n">tdbprint</span>
-<span class="kn">import</span> <span class="nn">theano.tensor</span> <span class="kn">as</span> <span class="nn">tt</span>
+<div class=" highlight hl-ipython3"><pre><span class="kn">import</span> <span class="nn">numpy</span> <span class="k">as</span> <span class="nn">np</span>
+<span class="kn">from</span> <span class="nn">plato.core</span> <span class="k">import</span> <span class="n">symbolic</span><span class="p">,</span> <span class="n">tdbprint</span>
+<span class="kn">import</span> <span class="nn">theano.tensor</span> <span class="k">as</span> <span class="nn">tt</span>
 <span class="kn">import</span> <span class="nn">theano</span>
 
 <span class="k">class</span> <span class="nc">Layer</span><span class="p">:</span>
@@ -622,7 +632,7 @@ ValueError: shapes (5,4) and (3,4) not aligned: 4 (dim 1) != 3 (dim 0)
     <span class="nd">@symbolic</span>
     <span class="k">def</span> <span class="nf">forward_pass</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">x</span><span class="p">):</span>
         <span class="n">pre_sigmoid</span> <span class="o">=</span> <span class="n">x</span><span class="o">.</span><span class="n">dot</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">w</span><span class="p">)</span>
-        <span class="n">tdbprint</span><span class="p">(</span><span class="n">pre_sigmoid</span><span class="p">,</span> <span class="n">name</span> <span class="o">=</span> <span class="s">&#39;Pre-Sigmoid Activation&#39;</span><span class="p">)</span>
+        <span class="n">tdbprint</span><span class="p">(</span><span class="n">pre_sigmoid</span><span class="p">,</span> <span class="n">name</span> <span class="o">=</span> <span class="s">&#39;Pre-Sigmoid Activation&#39;</span><span class="p">)</span>  <span class="c"># Here we make a trace of an internal variable</span>
         <span class="n">y</span> <span class="o">=</span> <span class="n">tt</span><span class="o">.</span><span class="n">nnet</span><span class="o">.</span><span class="n">sigmoid</span><span class="p">(</span><span class="n">pre_sigmoid</span><span class="p">)</span>
         <span class="k">return</span> <span class="n">y</span>
     
@@ -632,9 +642,9 @@ ValueError: shapes (5,4) and (3,4) not aligned: 4 (dim 1) != 3 (dim 0)
     
 <span class="n">layer</span> <span class="o">=</span> <span class="n">Layer</span><span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">random</span><span class="o">.</span><span class="n">randn</span><span class="p">(</span><span class="n">n_in</span><span class="p">,</span> <span class="n">n_out</span><span class="p">))</span>
 <span class="n">fwd_fcn</span> <span class="o">=</span> <span class="n">layer</span><span class="o">.</span><span class="n">forward_pass</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
-<span class="k">for</span> <span class="n">_</span> <span class="ow">in</span> <span class="nb">xrange</span><span class="p">(</span><span class="mi">3</span><span class="p">):</span>
+<span class="k">for</span> <span class="n">_</span> <span class="ow">in</span> <span class="n">xrange</span><span class="p">(</span><span class="mi">3</span><span class="p">):</span>
     <span class="n">y</span> <span class="o">=</span> <span class="n">fwd_fcn</span><span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">random</span><span class="o">.</span><span class="n">randn</span><span class="p">(</span><span class="n">n_samples</span><span class="p">,</span> <span class="n">n_in</span><span class="p">))</span>
-    <span class="k">print</span> <span class="s">&#39;Post Sigmoid Activation: </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">y</span><span class="p">)</span>
+    <span class="nb">print</span> <span class="s">&#39;Post Sigmoid Activation: %s&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">y</span><span class="p">)</span>
 </pre></div>
 
 </div>
@@ -647,12 +657,12 @@ ValueError: shapes (5,4) and (3,4) not aligned: 4 (dim 1) != 3 (dim 0)
 
 <div class="output_area"><div class="prompt"></div>
 <div class="output_subarea output_stream output_stdout output_text">
-<pre>Pre-Sigmoid Activation: [[ 0.00305122  1.05723461 -1.9052578 ]]
-Post Sigmoid Activation: [[ 0.50076281  0.74216172  0.12951455]]
-Pre-Sigmoid Activation: [[-0.07490342 -0.68868457  1.11345533]]
-Post Sigmoid Activation: [[ 0.4812829   0.33432576  0.75277273]]
-Pre-Sigmoid Activation: [[-0.94163796  1.2349249  -4.65812509]]
-Post Sigmoid Activation: [[ 0.2805696   0.77467938  0.00939512]]
+<pre>Pre-Sigmoid Activation: [[ 4.40823978 -3.22244603  2.0160825 ]]
+Post Sigmoid Activation: [[ 0.98796989  0.03832972  0.88247532]]
+Pre-Sigmoid Activation: [[-0.84914375  1.78727461  1.03616111]]
+Post Sigmoid Activation: [[ 0.29961251  0.85659281  0.73810861]]
+Pre-Sigmoid Activation: [[-0.31623953  1.34197376  1.74131986]]
+Post Sigmoid Activation: [[ 0.42159248  0.79281434  0.85085463]]
 </pre>
 </div>
 </div>
@@ -678,12 +688,13 @@ Post Sigmoid Activation: [[ 0.2805696   0.77467938  0.00939512]]
 <div class="text_cell_render border-box-sizing rendered_html">
 <h2 id="7.-Enforcing-Interfaces">7. Enforcing Interfaces<a class="anchor-link" href="#7.-Enforcing-Interfaces">&#182;</a></h2><p>In larger programs, it can be useful to enforce interfaces - that is, functions are required to obey a certain contract.  This allows function A to use function B without knowing in particular which function it is.  For instance, you may have some code that iterates through a dataset and trains a predictor, but doesn't necessarily know what kind of predictor it is - just that it has a <em>train</em> function that accepts inputs and targets, and returns updates.</p>
 <p>For this reason, we have an extended set of decorators which enforce type-checking on inputs, outputs, and updates.</p>
-<p><code>@symbolic</code> - No format requirements.
-<code>@symbolic_simple</code> - Returns a single output variable.<br>
-<code>@symbolic_multi</code> - Returns a tuple of output tensors.<br>
-<code>@symbolic_stateless</code> - Makes no state updates.
-<code>@symbolic_updater</code> - Returns nothing and produces at least one state update.</p>
-<p>Functions decorated with one of the above decorators throw a <code>SymbolicFormatError</code> when the function does not obey the contract specified by its decorator.</p>
+<p><strong><code>@symbolic</code></strong> - No format requirements.<br>
+<strong><code>@symbolic_simple</code></strong> - Returns a single output variable.<br>
+<strong><code>@symbolic_multi</code></strong> - Returns a tuple of output tensors.<br>
+<strong><code>@symbolic_stateless</code></strong> - Makes no state updates.<br>
+<strong><code>@symbolic_updater</code></strong> - Returns nothing and produces at least one state update.</p>
+<p>To make custom function con you can decorate with <strong><code>@SymbolicFunction(input_format, output_format, update_format)</code></strong>, where each of the arguments is an <code>IFormat</code> object.  See <code>plato.core</code> for examples.</p>
+<p>When function fail to obey the contract specified by their decorators, a <code>SymbolicFormatError</code> is raised.</p>
 <p>For example:</p>
 
 </div>
@@ -691,12 +702,13 @@ Post Sigmoid Activation: [[ 0.2805696   0.77467938  0.00939512]]
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[22]:</div>
+<div class="prompt input_prompt">In&nbsp;[2]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic_stateless</span><span class="p">,</span> <span class="n">symbolic</span><span class="p">,</span> <span class="n">SymbolicFormatError</span><span class="p">,</span> <span class="n">add_update</span>
+<div class=" highlight hl-ipython3"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="k">import</span> <span class="n">symbolic_stateless</span><span class="p">,</span> <span class="n">symbolic</span><span class="p">,</span> <span class="n">SymbolicFormatError</span><span class="p">,</span> <span class="n">add_update</span>
+<span class="kn">import</span> <span class="nn">theano</span>
 
-<span class="nd">@symbolic_stateless</span> <span class="c"># Bad! We decorated with &quot;symbolic_stateless&quot; but we make a state update inside</span>
+<span class="nd">@symbolic_stateless</span> <span class="c"># Bad! We decorated with &quot;symbolic_stateless&quot;, but we make a state update inside</span>
 <span class="k">def</span> <span class="nf">running_sum</span><span class="p">(</span><span class="n">x</span><span class="p">):</span>
     <span class="n">shared_var</span> <span class="o">=</span> <span class="n">theano</span><span class="o">.</span><span class="n">shared</span><span class="p">(</span><span class="mi">0</span><span class="p">)</span>
     <span class="n">y</span> <span class="o">=</span> <span class="n">x</span> <span class="o">+</span> <span class="n">shared_var</span>
@@ -704,13 +716,13 @@ Post Sigmoid Activation: [[ 0.2805696   0.77467938  0.00939512]]
     <span class="k">return</span> <span class="n">y</span> 
 
 <span class="n">f</span> <span class="o">=</span> <span class="n">running_sum</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
-<span class="k">print</span> <span class="s">&#39;Trying to run incorrectly-decorated function...&#39;</span>
+<span class="nb">print</span> <span class="s">&#39;Trying to run incorrectly-decorated function...&#39;</span>
 <span class="k">try</span><span class="p">:</span> 
     <span class="n">f</span><span class="p">(</span><span class="mi">3</span><span class="p">)</span>
 <span class="k">except</span> <span class="n">SymbolicFormatError</span> <span class="k">as</span> <span class="n">err</span><span class="p">:</span>
-    <span class="k">print</span> <span class="s">&#39;  </span><span class="si">%s</span><span class="s">: </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">err</span><span class="o">.</span><span class="n">__class__</span><span class="o">.</span><span class="n">__name__</span><span class="p">,</span> <span class="n">err</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
+    <span class="nb">print</span> <span class="s">&#39;  %s: %s&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">err</span><span class="o">.</span><span class="n">__class__</span><span class="o">.</span><span class="n">__name__</span><span class="p">,</span> <span class="n">err</span><span class="o">.</span><span class="n">message</span><span class="p">)</span>
 
-<span class="k">print</span> <span class="s">&#39;Lets try again with the correct format....&#39;</span>
+<span class="nb">print</span> <span class="s">&#39;Lets try again with the correct format....&#39;</span>
 
 <span class="nd">@symbolic</span>
 <span class="k">def</span> <span class="nf">running_sum</span><span class="p">(</span><span class="n">x</span><span class="p">):</span>
@@ -721,7 +733,7 @@ Post Sigmoid Activation: [[ 0.2805696   0.77467938  0.00939512]]
 
 <span class="n">f</span> <span class="o">=</span> <span class="n">running_sum</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
 
-<span class="k">print</span> <span class="s">&#39;  cumsum([1,2,3,4]) = </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">([</span><span class="nb">int</span><span class="p">(</span><span class="n">f</span><span class="p">(</span><span class="n">i</span><span class="p">))</span> <span class="k">for</span> <span class="n">i</span> <span class="ow">in</span> <span class="nb">xrange</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="mi">5</span><span class="p">)],</span> <span class="p">)</span>
+<span class="nb">print</span> <span class="s">&#39;  cumsum([1,2,3,4]) = %s&#39;</span> <span class="o">%</span> <span class="p">([</span><span class="nb">int</span><span class="p">(</span><span class="n">f</span><span class="p">(</span><span class="n">i</span><span class="p">))</span> <span class="k">for</span> <span class="n">i</span> <span class="ow">in</span> <span class="n">xrange</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="mi">5</span><span class="p">)],</span> <span class="p">)</span>
 </pre></div>
 
 </div>
@@ -735,7 +747,7 @@ Post Sigmoid Activation: [[ 0.2805696   0.77467938  0.00939512]]
 <div class="output_area"><div class="prompt"></div>
 <div class="output_subarea output_stream output_stdout output_text">
 <pre>Trying to run incorrectly-decorated function...
-  SymbolicFormatError: Function &lt;function running_sum at 0x10e8120c8&gt; should have created no state updates, but it created updates: [(&lt;TensorType(int64, scalar)&gt;, Elemwise{add,no_inplace}.0)]
+  SymbolicFormatError: Function &lt;function running_sum at 0x107169ed8&gt; should have created no state updates, but it created updates: [(&lt;TensorType(int64, scalar)&gt;, Elemwise{add,no_inplace}.0)]
 Lets try again with the correct format....
   cumsum([1,2,3,4]) = [1, 3, 6, 10]
 </pre>
@@ -758,10 +770,10 @@ Lets try again with the correct format....
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[23]:</div>
+<div class="prompt input_prompt">In&nbsp;[1]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic</span>
+<div class=" highlight hl-ipython3"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="k">import</span> <span class="n">symbolic</span>
 
 <span class="nd">@symbolic</span>
 <span class="k">def</span> <span class="nf">multiply</span><span class="p">(</span><span class="n">x</span><span class="p">,</span> <span class="n">y</span><span class="p">):</span>
@@ -769,8 +781,8 @@ Lets try again with the correct format....
 
 <span class="n">f_mult_by_3</span> <span class="o">=</span> <span class="n">multiply</span><span class="o">.</span><span class="n">compile</span><span class="p">(</span><span class="n">fixed_args</span> <span class="o">=</span> <span class="nb">dict</span><span class="p">(</span><span class="n">x</span><span class="o">=</span><span class="mi">3</span><span class="p">))</span>
 
-<span class="k">print</span> <span class="s">&#39;3*2 = </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="n">f_mult_by_3</span><span class="p">(</span><span class="n">y</span><span class="o">=</span><span class="mi">2</span><span class="p">)</span>
-<span class="k">print</span> <span class="s">&#39;3*5 = </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="n">f_mult_by_3</span><span class="p">(</span><span class="n">y</span><span class="o">=</span><span class="mi">5</span><span class="p">)</span>
+<span class="nb">print</span> <span class="s">&#39;3*2 = %s&#39;</span> <span class="o">%</span> <span class="n">f_mult_by_3</span><span class="p">(</span><span class="n">y</span><span class="o">=</span><span class="mi">2</span><span class="p">)</span>
+<span class="nb">print</span> <span class="s">&#39;3*5 = %s&#39;</span> <span class="o">%</span> <span class="n">f_mult_by_3</span><span class="p">(</span><span class="n">y</span><span class="o">=</span><span class="mi">5</span><span class="p">)</span>
 </pre></div>
 
 </div>
@@ -808,7 +820,7 @@ Lets try again with the correct format....
 <div class="prompt input_prompt">In&nbsp;[&nbsp;]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre> 
+<div class=" highlight hl-ipython3"><pre> 
 </pre></div>
 
 </div>

--- a/plato_tutorial.html
+++ b/plato_tutorial.html
@@ -197,7 +197,7 @@ div#notebook {
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[5]:</div>
+<div class="prompt input_prompt">In&nbsp;[3]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic</span>
@@ -241,7 +241,7 @@ div#notebook {
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[16]:</div>
+<div class="prompt input_prompt">In&nbsp;[2]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span class="kn">import</span> <span class="nn">theano</span>
@@ -289,32 +289,35 @@ div#notebook {
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<h2 id="2.-Adding-State">2. Adding State<a class="anchor-link" href="#2.-Adding-State">&#182;</a></h2><p>We are also able to create stateful functions.  Since theano follows a functional paradigm, state updates are represented explicitely in the return value as pairs of <code>(symbolic_shared_variable, symbolic_updated_variable)</code>.  In the below example, Plato recognises that the return value is in the format "<code>output, [(shared_variable, shared_variable_update)]</code>", so it creates a stateful function when it compiles.</p>
+<h2 id="2.-Adding-State">2. Adding State<a class="anchor-link" href="#2.-Adding-State">&#182;</a></h2><p>We are also able to create stateful functions.  Unlike Theano, we do not pass state-updates in the return value.  Instead, we call the function <code>add_update(shared_var, new_value)</code>.  The following example shows how to make a "function" with some internal state that updates on each call.</p>
 
 </div>
 </div>
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[7]:</div>
+<div class="prompt input_prompt">In&nbsp;[14]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span class="kn">import</span> <span class="nn">theano</span>
-<span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic</span>
+<span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic</span><span class="p">,</span> <span class="n">add_update</span>
 
 <span class="nd">@symbolic</span>
 <span class="k">def</span> <span class="nf">counter</span><span class="p">():</span>
-    <span class="n">counter</span> <span class="o">=</span> <span class="n">theano</span><span class="o">.</span><span class="n">shared</span><span class="p">(</span><span class="mi">0</span><span class="p">)</span>  <span class="c"># Create a shared variable, initialized at zero, which stores the count.</span>
-    <span class="n">new_count</span> <span class="o">=</span> <span class="n">counter</span><span class="o">+</span><span class="mi">1</span>
-    <span class="k">return</span> <span class="n">new_count</span><span class="p">,</span> <span class="p">[(</span><span class="n">counter</span><span class="p">,</span> <span class="n">new_count</span><span class="p">)]</span>
+    <span class="n">count</span> <span class="o">=</span> <span class="n">theano</span><span class="o">.</span><span class="n">shared</span><span class="p">(</span><span class="mi">0</span><span class="p">)</span>  <span class="c"># Create a shared variable, initialized at zero, which stores the count.</span>
+    <span class="n">new_count</span> <span class="o">=</span> <span class="n">count</span><span class="o">+</span><span class="mi">1</span>
+    <span class="n">add_update</span><span class="p">(</span><span class="n">count</span><span class="p">,</span> <span class="n">new_count</span><span class="p">)</span>
+    <span class="k">return</span> <span class="n">new_count</span>
 
 <span class="n">f</span> <span class="o">=</span> <span class="n">counter</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
 <span class="k">print</span> <span class="s">&#39;I can count to ten.  See: </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">([</span><span class="nb">int</span><span class="p">(</span><span class="n">f</span><span class="p">())</span> <span class="k">for</span> <span class="n">_</span> <span class="ow">in</span> <span class="nb">xrange</span><span class="p">(</span><span class="mi">10</span><span class="p">)])</span>
 
-<span class="c"># Note that we start from scratch when we compile the function a new time, </span>
-<span class="c"># because the shared variable is initialized within the function call</span>
 <span class="n">f2</span> <span class="o">=</span> <span class="n">counter</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
 <span class="k">print</span> <span class="s">&#39;I can too: </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">([</span><span class="nb">int</span><span class="p">(</span><span class="n">f2</span><span class="p">())</span> <span class="k">for</span> <span class="n">_</span> <span class="ow">in</span> <span class="nb">xrange</span><span class="p">(</span><span class="mi">10</span><span class="p">)])</span>
+<span class="c"># Note that we start from scratch when we compile the function a new time, </span>
+<span class="c"># because the shared variable is initialized within the function call.  If we</span>
+<span class="c"># had declaired counter outside the function, the second count would run from </span>
+<span class="c"># 11 to 20.</span>
 </pre></div>
 
 </div>
@@ -342,46 +345,6 @@ I can too: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p>Plato will recognise the following return formats:</p>
-<table>
-<thead><tr>
-<th>Format</th>
-<th style="text-align:left">Name/ Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>out</code></td>
-<td style="text-align:left"><strong>simple</strong>: An output tensor variable</td>
-</tr>
-<tr>
-<td><code>(out_0, out_1, ...)</code></td>
-<td style="text-align:left"><strong>multi</strong>: A tuple of output tensor variables</td>
-</tr>
-<tr>
-<td><code>[(shared_0, new_val_0), (shared_1, new_val_1), ...]</code></td>
-<td style="text-align:left"><strong>updater</strong>: A list of updates to shared variables</td>
-</tr>
-<tr>
-<td><code>out, [(shared_0, new_val_0), (shared_1, new_val_1), ...]</code></td>
-<td style="text-align:left"><strong>single output updater</strong>: A single output and a list of updates</td>
-</tr>
-<tr>
-<td><code>(out_0, out_1, ...), [(shared_0, new_val_0), (shared_1, new_val_1), ...]</code></td>
-<td style="text-align:left"><strong>standard</strong>: A tuple of outputs and a list of updates</td>
-</tr>
-</tbody>
-</table>
-<p>See <em>Section 7: Enforcing Interfaces</em>, for more on the exciting topic of data formats.</p>
-
-</div>
-</div>
-</div>
-<div class="cell border-box-sizing text_cell rendered">
-<div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
-<div class="text_cell_render border-box-sizing rendered_html">
 <h2 id="3.-Classes:-Multiple-functions-sharing-a-variable.">3. Classes: Multiple functions sharing a variable.<a class="anchor-link" href="#3.-Classes:-Multiple-functions-sharing-a-variable.">&#182;</a></h2><p>We often have situations where we have a variable that is shared between two functions (e.g. in a classifier, the weights may be modified by the <em>train</em> function and used by the <em>predict</em> function).  We usually deal with this using classes.  As a simple example, lets take the <a href="https://en.wikipedia.org/wiki/Collatz_conjecture">Collatz Conjecture</a>.</p>
 
 </div>
@@ -389,10 +352,10 @@ I can too: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[8]:</div>
+<div class="prompt input_prompt">In&nbsp;[17]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic</span>
+<div class=" highlight hl-ipython2"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic</span><span class="p">,</span> <span class="n">add_update</span>
 <span class="kn">import</span> <span class="nn">theano</span>
 
 <span class="k">class</span> <span class="nc">Collatz</span><span class="p">:</span>
@@ -403,12 +366,14 @@ I can too: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     <span class="nd">@symbolic</span>
     <span class="k">def</span> <span class="nf">divide_by_2</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
         <span class="n">new_value</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">value</span><span class="o">/</span><span class="mi">2</span>
-        <span class="k">return</span> <span class="n">new_value</span><span class="p">,</span> <span class="p">[(</span><span class="bp">self</span><span class="o">.</span><span class="n">value</span><span class="p">,</span> <span class="n">new_value</span><span class="p">)]</span>
+        <span class="n">add_update</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">value</span><span class="p">,</span> <span class="n">new_value</span><span class="p">)</span>
+        <span class="k">return</span> <span class="n">new_value</span>
     
     <span class="nd">@symbolic</span>
     <span class="k">def</span> <span class="nf">multiply_by_3_and_add_one</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
         <span class="n">new_value</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">value</span><span class="o">*</span><span class="mi">3</span><span class="o">+</span><span class="mi">1</span>
-        <span class="k">return</span> <span class="n">new_value</span><span class="p">,</span> <span class="p">[(</span><span class="bp">self</span><span class="o">.</span><span class="n">value</span><span class="p">,</span> <span class="n">new_value</span><span class="p">)]</span>
+        <span class="n">add_update</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">value</span><span class="p">,</span> <span class="n">new_value</span><span class="p">)</span>
+        <span class="k">return</span> <span class="n">new_value</span>
     
 <span class="n">c</span> <span class="o">=</span> <span class="n">Collatz</span><span class="p">(</span><span class="mi">20</span><span class="p">)</span>
 <span class="n">div_fcn</span> <span class="o">=</span> <span class="n">c</span><span class="o">.</span><span class="n">divide_by_2</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
@@ -421,7 +386,7 @@ I can too: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     <span class="n">value</span> <span class="o">=</span> <span class="n">div_fcn</span><span class="p">()</span> <span class="k">if</span> <span class="n">value</span> <span class="o">%</span> <span class="mi">2</span> <span class="o">==</span> <span class="mi">0</span> <span class="k">else</span> <span class="n">mul_fcn</span><span class="p">()</span>
     <span class="k">print</span> <span class="n">value</span>
 
-<span class="k">print</span> <span class="s">&#39;Note that since the value is attached to the class, it persists if functons are recompiled.&#39;</span>
+<span class="k">print</span> <span class="s">&#39;Note that since the value is attached to the instance, it persists if functons are recompiled.&#39;</span>
 <span class="n">new_div_fcn</span> <span class="o">=</span> <span class="n">c</span><span class="o">.</span><span class="n">divide_by_2</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
 <span class="n">new_mul_fcn</span> <span class="o">=</span> <span class="n">c</span><span class="o">.</span><span class="n">multiply_by_3_and_add_one</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
 <span class="k">for</span> <span class="n">_</span> <span class="ow">in</span> <span class="nb">xrange</span><span class="p">(</span><span class="mi">6</span><span class="p">):</span>
@@ -447,7 +412,7 @@ I can too: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 4
 2
 1
-Note that since the value is attached to the class, it persists if functons are recompiled.
+Note that since the value is attached to the instance, it persists if functons are recompiled.
 4
 2
 1
@@ -474,7 +439,7 @@ Note that since the value is attached to the class, it persists if functons are 
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[9]:</div>
+<div class="prompt input_prompt">In&nbsp;[18]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic</span>
@@ -524,7 +489,7 @@ Note that since the value is attached to the class, it persists if functons are 
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[10]:</div>
+<div class="prompt input_prompt">In&nbsp;[19]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic</span>
@@ -572,15 +537,20 @@ You were inconsistent - referenced x as a kwarg in the first call but not the se
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h2 id="6.-Debugging">6. Debugging<a class="anchor-link" href="#6.-Debugging">&#182;</a></h2><p>A big advantage of Plato is easier debugging.  There are two ways in which Plato helps you debug.</p>
-<h3 id="6A:-Test-values">6A: Test values<a class="anchor-link" href="#6A:-Test-values">&#182;</a></h3><p>Theano allows you to add "test-values" to your symbolic variables (<a href="http://deeplearning.net/software/theano/tutorial/debug_faq.html">see tutorial</a>).  This helps to catch shape-errors at compile-time instead of run-time, where it is difficult to find the line of code that caused them.  However, it can be a bit of extra work for the programmer, because they have to manually attach test values to their variables.  Fortunately, since Plato compiles your functions on the first pass, it can attach test-values "under the hood".</p>
+<h3 id="6A:-Testing-Initial-Values">6A: Testing Initial Values<a class="anchor-link" href="#6A:-Testing-Initial-Values">&#182;</a></h3><p>Theano allows you to add "test-values" to your symbolic variables (<a href="http://deeplearning.net/software/theano/tutorial/debug_faq.html">see tutorial</a>).  This helps to catch shape-errors at compile-time instead of run-time, where it is difficult to find the line of code that caused them.  However, it can be a bit of extra work for the programmer, because they have to manually attach test values to their variables.  Fortunately, since Plato compiles your functions on the first pass, it can attach test-values "under the hood".</p>
 <p>For example, lets look at a matrix multiplication, where we accidently get the shapes of our matrices wrong.  Since all inputs are given test values, we can easily track down the error - the traceback will lead back to the correct line.  This would not have been possible without test values, because the error would occur in the compiled code, which is no-longer linked to the source code.</p>
+<p>Plato attaches the following properties to all symbolic variables:<br>
+<strong>var.ival</strong> - The initial value of the variable (a numpy array or scalar)<br>
+<strong>var.ishape</strong> - The initial shape of the variable<br>
+<strong>var.indim</strong> - The initial number of dimensions of the variable<br>
+<strong>var.idtype</strong> - The initial dtype of the variable</p>
 
 </div>
 </div>
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[11]:</div>
+<div class="prompt input_prompt">In&nbsp;[20]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span class="kn">import</span> <span class="nn">numpy</span> <span class="kn">as</span> <span class="nn">np</span>
@@ -588,8 +558,8 @@ You were inconsistent - referenced x as a kwarg in the first call but not the se
 
 <span class="nd">@symbolic</span>
 <span class="k">def</span> <span class="nf">forward_pass</span><span class="p">(</span><span class="n">x</span><span class="p">,</span> <span class="n">w</span><span class="p">):</span>
-    <span class="k">print</span> <span class="s">&#39;x-shape: </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">x</span><span class="o">.</span><span class="n">tag</span><span class="o">.</span><span class="n">test_value</span><span class="o">.</span><span class="n">shape</span><span class="p">,</span> <span class="p">)</span>
-    <span class="k">print</span> <span class="s">&#39;w-shape: </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">w</span><span class="o">.</span><span class="n">tag</span><span class="o">.</span><span class="n">test_value</span><span class="o">.</span><span class="n">shape</span><span class="p">,</span> <span class="p">)</span>
+    <span class="k">print</span> <span class="s">&#39;x-shape: </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">x</span><span class="o">.</span><span class="n">ishape</span><span class="p">,</span> <span class="p">)</span>
+    <span class="k">print</span> <span class="s">&#39;w-shape: </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">w</span><span class="o">.</span><span class="n">ishape</span><span class="p">,</span> <span class="p">)</span>
     <span class="c"># Note that the above test-values only display on the first iteration.</span>
     <span class="k">return</span> <span class="n">x</span><span class="o">.</span><span class="n">dot</span><span class="p">(</span><span class="n">w</span><span class="p">)</span>
 
@@ -636,7 +606,7 @@ ValueError: shapes (5,4) and (3,4) not aligned: 4 (dim 1) != 3 (dim 0)
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[12]:</div>
+<div class="prompt input_prompt">In&nbsp;[21]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span class="kn">import</span> <span class="nn">numpy</span> <span class="kn">as</span> <span class="nn">np</span>
@@ -662,8 +632,9 @@ ValueError: shapes (5,4) and (3,4) not aligned: 4 (dim 1) != 3 (dim 0)
     
 <span class="n">layer</span> <span class="o">=</span> <span class="n">Layer</span><span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">random</span><span class="o">.</span><span class="n">randn</span><span class="p">(</span><span class="n">n_in</span><span class="p">,</span> <span class="n">n_out</span><span class="p">))</span>
 <span class="n">fwd_fcn</span> <span class="o">=</span> <span class="n">layer</span><span class="o">.</span><span class="n">forward_pass</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
-<span class="n">y</span> <span class="o">=</span> <span class="n">fwd_fcn</span><span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">random</span><span class="o">.</span><span class="n">randn</span><span class="p">(</span><span class="n">n_samples</span><span class="p">,</span> <span class="n">n_in</span><span class="p">))</span>
-<span class="k">print</span> <span class="s">&#39;Post Sigmoid Activation: </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">y</span><span class="p">)</span>
+<span class="k">for</span> <span class="n">_</span> <span class="ow">in</span> <span class="nb">xrange</span><span class="p">(</span><span class="mi">3</span><span class="p">):</span>
+    <span class="n">y</span> <span class="o">=</span> <span class="n">fwd_fcn</span><span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">random</span><span class="o">.</span><span class="n">randn</span><span class="p">(</span><span class="n">n_samples</span><span class="p">,</span> <span class="n">n_in</span><span class="p">))</span>
+    <span class="k">print</span> <span class="s">&#39;Post Sigmoid Activation: </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">y</span><span class="p">)</span>
 </pre></div>
 
 </div>
@@ -676,8 +647,12 @@ ValueError: shapes (5,4) and (3,4) not aligned: 4 (dim 1) != 3 (dim 0)
 
 <div class="output_area"><div class="prompt"></div>
 <div class="output_subarea output_stream output_stdout output_text">
-<pre>Pre-Sigmoid Activation: [[ 4.82051976  0.89245079  0.8168448 ]]
-Post Sigmoid Activation: [[ 0.99200189  0.70939567  0.69356617]]
+<pre>Pre-Sigmoid Activation: [[ 0.00305122  1.05723461 -1.9052578 ]]
+Post Sigmoid Activation: [[ 0.50076281  0.74216172  0.12951455]]
+Pre-Sigmoid Activation: [[-0.07490342 -0.68868457  1.11345533]]
+Post Sigmoid Activation: [[ 0.4812829   0.33432576  0.75277273]]
+Pre-Sigmoid Activation: [[-0.94163796  1.2349249  -4.65812509]]
+Post Sigmoid Activation: [[ 0.2805696   0.77467938  0.00939512]]
 </pre>
 </div>
 </div>
@@ -702,33 +677,34 @@ Post Sigmoid Activation: [[ 0.99200189  0.70939567  0.69356617]]
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h2 id="7.-Enforcing-Interfaces">7. Enforcing Interfaces<a class="anchor-link" href="#7.-Enforcing-Interfaces">&#182;</a></h2><p>In larger programs, it can be useful to enforce interfaces - that is, functions are required to obey a certain contract.  This allows function A to use function B without knowing in particular which function it is.  For instance, you may have some code that iterates through a dataset and trains a predictor, but doesn't necessarily know what kind of predictor it is - just that it has a <em>train</em> function that accepts inputs and targets, and returns updates.</p>
-<p>For this reason, we have an extended set of decorators which enforce type-checking on inputs/outputs.  Currently all these decorators just specify outputs, but this can easily be extended to to type-checking for inputs too.</p>
-<p><code>@symbolic_simple</code> - Returns a single output variable.<br>
-<code>@symbolic_updater</code> - Returns a list of updates.<br>
-<code>@symbolic_standard</code> - Returns a tuple of outputs and a list of updates.<br>
-<code>@symbolic_multi</code> - Returns multiple output variables.<br>
-<code>@symbolic_single_output_updater</code> - Return a single output and list of updates.</p>
-<p>Refer to the table in <em>Section 2: Adding State</em> for a more detailed description of each of these formats.</p>
-<p>If you decorate with these, you get a <code>SymbolicFormatError</code> when your inputs/outputs are not in the expected format.  For example:</p>
+<p>For this reason, we have an extended set of decorators which enforce type-checking on inputs, outputs, and updates.</p>
+<p><code>@symbolic</code> - No format requirements.
+<code>@symbolic_simple</code> - Returns a single output variable.<br>
+<code>@symbolic_multi</code> - Returns a tuple of output tensors.<br>
+<code>@symbolic_stateless</code> - Makes no state updates.
+<code>@symbolic_updater</code> - Returns nothing and produces at least one state update.</p>
+<p>Functions decorated with one of the above decorators throw a <code>SymbolicFormatError</code> when the function does not obey the contract specified by its decorator.</p>
+<p>For example:</p>
 
 </div>
 </div>
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[13]:</div>
+<div class="prompt input_prompt">In&nbsp;[22]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic_standard</span><span class="p">,</span> <span class="n">SymbolicFormatError</span>
+<div class=" highlight hl-ipython2"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic_stateless</span><span class="p">,</span> <span class="n">symbolic</span><span class="p">,</span> <span class="n">SymbolicFormatError</span><span class="p">,</span> <span class="n">add_update</span>
 
-<span class="nd">@symbolic_standard</span>
-<span class="k">def</span> <span class="nf">multiply_by_two</span><span class="p">(</span><span class="n">x</span><span class="p">):</span>
-    <span class="n">y</span> <span class="o">=</span> <span class="mi">2</span><span class="o">*</span><span class="n">x</span>
-    <span class="k">return</span> <span class="n">y</span>  <span class="c"># Bad! We decorated with &quot;standard&quot; but did not return the standard format of (outputs, updates)</span>
+<span class="nd">@symbolic_stateless</span> <span class="c"># Bad! We decorated with &quot;symbolic_stateless&quot; but we make a state update inside</span>
+<span class="k">def</span> <span class="nf">running_sum</span><span class="p">(</span><span class="n">x</span><span class="p">):</span>
+    <span class="n">shared_var</span> <span class="o">=</span> <span class="n">theano</span><span class="o">.</span><span class="n">shared</span><span class="p">(</span><span class="mi">0</span><span class="p">)</span>
+    <span class="n">y</span> <span class="o">=</span> <span class="n">x</span> <span class="o">+</span> <span class="n">shared_var</span>
+    <span class="n">add_update</span><span class="p">(</span><span class="n">shared_var</span><span class="p">,</span> <span class="n">y</span><span class="p">)</span> 
+    <span class="k">return</span> <span class="n">y</span> 
 
-<span class="n">f</span> <span class="o">=</span> <span class="n">multiply_by_two</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
-
-<span class="k">print</span> <span class="s">&#39;Trying to run improperly formatted function...&#39;</span>
+<span class="n">f</span> <span class="o">=</span> <span class="n">running_sum</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
+<span class="k">print</span> <span class="s">&#39;Trying to run incorrectly-decorated function...&#39;</span>
 <span class="k">try</span><span class="p">:</span> 
     <span class="n">f</span><span class="p">(</span><span class="mi">3</span><span class="p">)</span>
 <span class="k">except</span> <span class="n">SymbolicFormatError</span> <span class="k">as</span> <span class="n">err</span><span class="p">:</span>
@@ -736,93 +712,16 @@ Post Sigmoid Activation: [[ 0.99200189  0.70939567  0.69356617]]
 
 <span class="k">print</span> <span class="s">&#39;Lets try again with the correct format....&#39;</span>
 
-<span class="nd">@symbolic_standard</span>
-<span class="k">def</span> <span class="nf">multiply_by_two_in_correct_format</span><span class="p">(</span><span class="n">x</span><span class="p">):</span>
-    <span class="n">y</span> <span class="o">=</span> <span class="mi">2</span><span class="o">*</span><span class="n">x</span>
-    <span class="k">return</span> <span class="p">(</span><span class="n">y</span><span class="p">,</span> <span class="p">),</span> <span class="p">[]</span>  <span class="c"># Correct &quot;standard&quot; format - a tuple of outputs and a list of updates (which is empty in this case)</span>
-
-<span class="n">f_again</span> <span class="o">=</span> <span class="n">multiply_by_two_in_correct_format</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
-
-<span class="k">print</span> <span class="s">&#39;  [3*2] = </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">f_again</span><span class="p">(</span><span class="mi">3</span><span class="p">),</span> <span class="p">)</span>
-</pre></div>
-
-</div>
-</div>
-</div>
-
-<div class="output_wrapper">
-<div class="output">
-
-
-<div class="output_area"><div class="prompt"></div>
-<div class="output_subarea output_stream output_stdout output_text">
-<pre>Trying to run improperly formatted function...
-  SymbolicFormatError: You did not return a 2-tuple of outputs, updates.  You returned Elemwise{mul,no_inplace}.0
-Lets try again with the correct format....
-  [3*2] = [array(6, dtype=int32)]
-</pre>
-</div>
-</div>
-
-</div>
-</div>
-
-</div>
-<div class="cell border-box-sizing text_cell rendered">
-<div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
-<div class="text_cell_render border-box-sizing rendered_html">
-<h2 id="8.-Converting-Formats">8. Converting Formats<a class="anchor-link" href="#8.-Converting-Formats">&#182;</a></h2><p>In the previous example, we saw that the <code>multiply_by_two</code> function was much cleaner than the <code>multiply_by_two_in_correct_format</code> function.  But if were to pass this function into some generic code that wants to treat functions interchangeably, we needed to implement it in the "standard" format.  To overcome the impracticality of forcing users to either implement functions in a messy way, or wrap them, symbolic functions have a <strong>to_format</strong> method to do format-conversion.</p>
-<p>As an example, lets imaging you're making a generic "Chain" function.  Chain's job is to compose a list of (possible stateful) functions into a chain: $f_c = f_1 \circ f_2 \circ ... f_n$</p>
-<p>In our example, we'll have two functions - Multiply by two, and a cumulative sum.</p>
-<p>Note a few things here:</p>
-<ul>
-<li>We don't know, when creating Chain, what formats the inner funtions will have (Will they return updates?, Will they return a tuple of outputs or just a single one?)</li>
-<li>We therefore don't know what format the output of Chain should take (should it return just one output or a tuple, should it return updates, etc)</li>
-</ul>
-<p>The below example shows how we can use the <strong>to_format</strong> method to convert a symbolic function defined in one format to another.</p>
-
-</div>
-</div>
-</div>
-<div class="cell border-box-sizing code_cell rendered">
-<div class="input">
-<div class="prompt input_prompt">In&nbsp;[14]:</div>
-<div class="inner_cell">
-    <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic</span><span class="p">,</span> <span class="n">symbolic_standard</span><span class="p">,</span> <span class="n">symbolic_simple</span>
-<span class="kn">import</span> <span class="nn">theano</span>
-<span class="kn">import</span> <span class="nn">numpy</span> <span class="kn">as</span> <span class="nn">np</span>
-
-<span class="nd">@symbolic_standard</span>
-<span class="k">class</span> <span class="nc">Chain</span><span class="p">:</span>
-    
-    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">*</span><span class="n">functions</span><span class="p">):</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">functions</span> <span class="o">=</span> <span class="n">functions</span>
-        
-    <span class="k">def</span> <span class="nf">__call__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">*</span><span class="n">args</span><span class="p">):</span>
-        <span class="n">updates</span> <span class="o">=</span> <span class="p">[]</span>
-        <span class="k">for</span> <span class="n">f</span> <span class="ow">in</span> <span class="bp">self</span><span class="o">.</span><span class="n">functions</span><span class="p">:</span>
-            <span class="c"># Note how we convert to the standard format to get results in the (outputs, updates) format.</span>
-            <span class="n">args</span><span class="p">,</span> <span class="n">new_updates</span> <span class="o">=</span> <span class="n">f</span><span class="o">.</span><span class="n">to_format</span><span class="p">(</span><span class="n">symbolic_standard</span><span class="p">)(</span><span class="o">*</span><span class="n">args</span><span class="p">)</span>  <span class="c"># &quot;*&quot; is python syntax for unpacking a tuple as arguments.</span>
-            <span class="n">updates</span> <span class="o">+=</span> <span class="n">new_updates</span>  <span class="c"># Append the list of this function&#39;s state updates to the global list</span>
-        <span class="k">return</span> <span class="n">args</span><span class="p">,</span> <span class="n">updates</span>
-
-<span class="nd">@symbolic_simple</span>
-<span class="k">def</span> <span class="nf">multiply_by_two</span><span class="p">(</span><span class="n">x</span><span class="p">):</span>
-    <span class="k">return</span> <span class="n">x</span><span class="o">*</span><span class="mi">2</span>
-
 <span class="nd">@symbolic</span>
 <span class="k">def</span> <span class="nf">running_sum</span><span class="p">(</span><span class="n">x</span><span class="p">):</span>
-    <span class="n">z</span> <span class="o">=</span> <span class="n">theano</span><span class="o">.</span><span class="n">shared</span><span class="p">(</span><span class="mi">0</span><span class="p">)</span>
-    <span class="n">new_z</span> <span class="o">=</span> <span class="n">z</span><span class="o">+</span><span class="n">x</span>
-    <span class="k">return</span> <span class="n">new_z</span><span class="p">,</span> <span class="p">[(</span><span class="n">z</span><span class="p">,</span> <span class="n">new_z</span><span class="p">)]</span>
+    <span class="n">shared_var</span> <span class="o">=</span> <span class="n">theano</span><span class="o">.</span><span class="n">shared</span><span class="p">(</span><span class="mi">0</span><span class="p">)</span>
+    <span class="n">y</span> <span class="o">=</span> <span class="n">x</span> <span class="o">+</span> <span class="n">shared_var</span>
+    <span class="n">add_update</span><span class="p">(</span><span class="n">shared_var</span><span class="p">,</span> <span class="n">y</span><span class="p">)</span> 
+    <span class="k">return</span> <span class="n">y</span> 
 
-<span class="n">f</span> <span class="o">=</span> <span class="n">Chain</span><span class="p">(</span><span class="n">multiply_by_two</span><span class="p">,</span> <span class="n">running_sum</span><span class="p">)</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
+<span class="n">f</span> <span class="o">=</span> <span class="n">running_sum</span><span class="o">.</span><span class="n">compile</span><span class="p">()</span>
 
-<span class="k">for</span> <span class="n">i</span> <span class="ow">in</span> <span class="nb">xrange</span><span class="p">(</span><span class="mi">10</span><span class="p">):</span>
-    <span class="k">print</span> <span class="s">&#39;sum([0..</span><span class="si">%s</span><span class="s">]*2) = </span><span class="si">%s</span><span class="s"> &#39;</span> <span class="o">%</span> <span class="p">(</span><span class="n">i</span><span class="p">,</span> <span class="n">f</span><span class="p">(</span><span class="n">i</span><span class="p">))</span>
+<span class="k">print</span> <span class="s">&#39;  cumsum([1,2,3,4]) = </span><span class="si">%s</span><span class="s">&#39;</span> <span class="o">%</span> <span class="p">([</span><span class="nb">int</span><span class="p">(</span><span class="n">f</span><span class="p">(</span><span class="n">i</span><span class="p">))</span> <span class="k">for</span> <span class="n">i</span> <span class="ow">in</span> <span class="nb">xrange</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="mi">5</span><span class="p">)],</span> <span class="p">)</span>
 </pre></div>
 
 </div>
@@ -835,16 +734,10 @@ Lets try again with the correct format....
 
 <div class="output_area"><div class="prompt"></div>
 <div class="output_subarea output_stream output_stdout output_text">
-<pre>sum([0..0]*2) = [array(0)] 
-sum([0..1]*2) = [array(2)] 
-sum([0..2]*2) = [array(6)] 
-sum([0..3]*2) = [array(12)] 
-sum([0..4]*2) = [array(20)] 
-sum([0..5]*2) = [array(30)] 
-sum([0..6]*2) = [array(42)] 
-sum([0..7]*2) = [array(56)] 
-sum([0..8]*2) = [array(72)] 
-sum([0..9]*2) = [array(90)] 
+<pre>Trying to run incorrectly-decorated function...
+  SymbolicFormatError: Function &lt;function running_sum at 0x10e8120c8&gt; should have created no state updates, but it created updates: [(&lt;TensorType(int64, scalar)&gt;, Elemwise{add,no_inplace}.0)]
+Lets try again with the correct format....
+  cumsum([1,2,3,4]) = [1, 3, 6, 10]
 </pre>
 </div>
 </div>
@@ -858,14 +751,14 @@ sum([0..9]*2) = [array(90)]
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<h2 id="9.-Fixed-Arguments">9. Fixed Arguments<a class="anchor-link" href="#9.-Fixed-Arguments">&#182;</a></h2><p>When you use a numpy array on a theano symbolic function, it treats it as a constant.  We can use the <strong>fixed_args</strong> argument to <strong>compile()</strong> to partially-specify a function.  Theano will then compile the function with these arguments as fixed constants.  For example:</p>
+<h2 id="8.-Fixed-Arguments">8. Fixed Arguments<a class="anchor-link" href="#8.-Fixed-Arguments">&#182;</a></h2><p>When you use a numpy array on a theano symbolic function, it treats it as a constant.  We can use the <strong>fixed_args</strong> argument to <strong>compile()</strong> to partially-specify a function.  Theano will then compile the function with these arguments as fixed constants.  For example:</p>
 
 </div>
 </div>
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[15]:</div>
+<div class="prompt input_prompt">In&nbsp;[23]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython2"><pre><span class="kn">from</span> <span class="nn">plato.core</span> <span class="kn">import</span> <span class="n">symbolic</span>
@@ -905,10 +798,23 @@ sum([0..9]*2) = [array(90)]
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<h2 id="10.-Done.">10. Done.<a class="anchor-link" href="#10.-Done.">&#182;</a></h2><p>Congratulations, you made it through the Plato tutorial.</p>
+<h2 id="9.-Done.">9. Done.<a class="anchor-link" href="#9.-Done.">&#182;</a></h2><p>Congratulations, you made it through the Plato tutorial.</p>
 
 </div>
 </div>
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[&nbsp;]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython2"><pre> 
+</pre></div>
+
+</div>
+</div>
+</div>
+
 </div>
     </div>
   </div>


### PR DESCRIPTION
This is a big change, but a good one.   We remove the notion of explicitly passing around state updates, and instead call a function `add_update(shared_var, new_val)` to create an updating state variable.  This will make for cleaner code in the end.
